### PR TITLE
[Add] protected fs for Unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(COV OFF "Turn on coverage or not")
 # =============== VARIABLES FOR MANUAL CHANGE BEGIN ===============
 set(UNIX_APPS config_gen integration_test private_join_and_compute ml_predict quickstart
 image_resizing online_decrypt rsa_sign py_matrix_multiply kmeans)
-set(UNIX_LIBS mesatee_sdk)
+set(UNIX_LIBS mesatee_sdk protected_fs_rs)
 # need relative path for SGX_MODULE_PATHS to find Enclave.config.xml
 set(SGX_MODULE_PATHS mesatee_services/kms mesatee_services/tdfs mesatee_services/tms
     mesatee_services/fns tests/functional_test)

--- a/LICENSE
+++ b/LICENSE
@@ -203,6 +203,7 @@
 The MesaTEE project uses third-party sources that may be distributed under
 different licenses. Please see below for details.
 
+
 License for Rust SGX SDK (`https://github.com/baidu/rust-sgx-sdk`)
 ------------------------------------------------------------------
 
@@ -272,3 +273,37 @@ License for WABT bindings for Rust (`https://github.com/pepyakin/wabt-rs`)
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+License for Intel SGX SDK (`https://github.com/intel/linux-sgx`)
+----------------------------------------------------------------
+
+BSD License
+
+Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+  * Neither the name of Intel Corporation nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmake/scripts/setup_cmake_tomls
+++ b/cmake/scripts/setup_cmake_tomls
@@ -14,6 +14,7 @@ sym_folders = [
 'examples',
 'cert',
 'mesatee_sdk',
+'mesatee_utils',
 'mesatee_services',
 'toolchain_deps',
 'auditors',

--- a/cmake/scripts/sgx_test.sh
+++ b/cmake/scripts/sgx_test.sh
@@ -14,5 +14,7 @@ ias_spid.txt and ias_key.txt, and put in the bin";
         exit 1;
     fi
 fi
+
+cd ${MESATEE_PROJECT_ROOT}/tests && ./module_test.sh
 cd ${MESATEE_PROJECT_ROOT}/tests && ./functional_test.sh
 cd ${MESATEE_PROJECT_ROOT}/tests && ./integration_test.sh

--- a/mesatee_binder/Enclave.edl
+++ b/mesatee_binder/Enclave.edl
@@ -20,6 +20,7 @@ enclave {
     from "sgx_fs.edl" import *;
     from "sgx_net.edl" import *;
     from "sgx_env.edl" import *;
+    from "sgx_tprotected_fs.edl" import *;
 
     trusted {
         /* define ECALLs here. */

--- a/mesatee_binder/build.rs
+++ b/mesatee_binder/build.rs
@@ -27,6 +27,7 @@ fn choose_sgx_dylib(is_sim: bool) {
 fn main() {
     let sdk_dir = env::var("SGX_SDK").unwrap_or("/opt/intel/sgxsdk".into());
     println!("cargo:rustc-link-search=native={}/lib64", sdk_dir);
+    println!("cargo:rustc-link-lib=static=sgx_uprotected_fs");
 
     let is_sim = match env::var("SGX_MODE") {
         Ok(ref v) if v == "SW" => true,

--- a/mesatee_utils/protected_fs_rs/Cargo.toml
+++ b/mesatee_utils/protected_fs_rs/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "protected_fs_rs"
+version = "0.0.1"
+authors = ["MesaTEE Authors <developers@mesatee.org>"]
+description = "Ported sgx_protected_fs (Intel SGX SDK) running out side sgx with Rust bindings."
+license-file = "Apache-2.0"
+edition = "2018"
+
+[lib]
+name = "protected_fs"
+crate-type = ["rlib"]
+
+[features]
+default = ["libc", "rand"]
+mesalock_sgx = ["sgx_tstd", "sgx_types", "sgx_trts"]
+
+[dependencies]
+libc        = { version = "0.2", optional = true }
+rand        = { version = "0.6.5", optional = true }
+cfg-if      = { version = "0.1.9" }
+sgx_tstd    = { version = "1.0.8", optional = true }
+sgx_types   = { version = "1.0.8", optional = true }
+sgx_trts    = { version = "1.0.8", optional = true }
+
+[build-dependencies]
+cfg-if      = { version = "0.1.9" }

--- a/mesatee_utils/protected_fs_rs/build.rs
+++ b/mesatee_utils/protected_fs_rs/build.rs
@@ -1,0 +1,84 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cfg_if::cfg_if;
+use std::env;
+
+cfg_if! {
+    if #[cfg(feature = "mesalock_sgx")]  {
+        const LIB_T_PROTECTED_FS_NAME: &'static str = "sgx_tprotected_fs";
+    } else {
+        use std::path::PathBuf;
+        use std::process::Command;
+        const LIBPROTECTED_FS_NAME: &'static str = "protected_fs";
+        const PROTECTED_FS_C_NAME: &'static str = "protected_fs_c";
+    }
+}
+
+#[cfg(not(feature = "mesalock_sgx"))]
+fn build_protected_fs_c() {
+    Command::new("make")
+        .arg("--version")
+        .output()
+        .expect("make not found");
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let source_dir = manifest_dir.join(PROTECTED_FS_C_NAME);
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let build_dir = out_dir.join(PROTECTED_FS_C_NAME);
+
+    let output = Command::new("make")
+        .current_dir(&source_dir)
+        .env("CXXFLAGS", "")
+        .env("PROTECTED_FS_OUT_DIR", &build_dir)
+        .output()
+        .expect("failed to compile protected_fs_c");
+    if !output.status.success() {
+        panic!("failed to compile protected_fs_c");
+    }
+
+    env::set_var("PROTECTED_FS_LIB_DIR", &build_dir);
+    env::set_var("PROTECTED_FS_STATIC", "true");
+}
+
+cfg_if! {
+    if #[cfg(feature = "mesalock_sgx")] {
+        fn build() {
+            let sdk_dir = env::var("SGX_SDK").unwrap_or("/opt/intel/sgxsdk".into());
+            println!("cargo:rustc-link-search=native={}/lib64", sdk_dir);
+            println!("cargo:rustc-link-lib=static={}", LIB_T_PROTECTED_FS_NAME);
+        }
+    } else {
+        fn build() {
+            build_protected_fs_c();
+
+            if let Ok(lib_dir) = env::var("PROTECTED_FS_LIB_DIR") {
+                println!("cargo:rustc-link-search=native={}", lib_dir);
+                let mode = match env::var_os("PROTECTED_FS_STATIC") {
+                    Some(_) => "static",
+                    None => panic!("Not supported dylib."),
+                };
+                println!("cargo:rustc-link-lib={}={}", mode, LIBPROTECTED_FS_NAME);
+            } else {
+                panic!("Env var {} not set", "PROTECTED_FS_LIB_DIR");
+            }
+            println!("cargo:rustc-link-lib=crypto");
+            println!("cargo:rustc-link-lib=stdc++");
+        }
+    }
+}
+
+fn main() {
+    build();
+}

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/Makefile
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/Makefile
@@ -1,0 +1,89 @@
+#
+# Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+PROTECTED_FS_PROJECT_ROOT ?= $(CURDIR)
+PROTECTED_FS_OUT_DIR ?= /tmp/protected_fs
+PROTECTED_FS_LIB_NAME ?= libprotected_fs.a
+TSGX_DIR := sgx_tprotected_fs
+USGX_DIR := sgx_uprotected_fs
+
+PROJECT_ROOT := $(PROTECTED_FS_PROJECT_ROOT)
+OUT_DIR := $(PROTECTED_FS_OUT_DIR)
+
+INCLUDE += -I$(PROJECT_ROOT) -I$(PROJECT_ROOT)/inc
+CXXFLAGS += -Werror -U__STRICT_ANSI__ -std=c++11 -lpthread
+CXXFLAGS += -Wno-unused-local-typedefs -Wno-shadow -Wno-missing-field-initializers -Wno-unused-parameter
+
+
+ABS_SRC := $(wildcard $(PROJECT_ROOT)/$(TSGX_DIR)/*.cpp) $(wildcard $(PROJECT_ROOT)/$(USGX_DIR)/*.cpp)
+SORTED_ABS_SRC := $(sort $(ABS_SRC))
+SORTED_ABS_OBJ := $(SORTED_ABS_SRC:.cpp=.o)
+
+ABS_OBJ := $(patsubst $(PROTECTED_FS_PROJECT_ROOT)/%,$(OUT_DIR)/%,$(SORTED_ABS_OBJ))
+SRC := $(ABS_SRC)
+OBJ := $(ABS_OBJ)
+
+EXAMPLE_DIR := $(PROTECTED_FS_PROJECT_ROOT)/example
+EXAMPLE_SRC := $(EXAMPLE_DIR)/example.c
+EXAMPLE_EXE := $(EXAMPLE_DIR)/example
+EXAMPLE_OUTPUT := $(EXAMPLE_DIR)/data_file
+EXAMPLE_DEP_OPTION := -lcrypto
+
+TARGET:= $(OUT_DIR)/$(PROTECTED_FS_LIB_NAME)
+
+.PHONY: all
+all: $(TARGET)
+
+.PHONY: example
+example: $(EXAMPLE_EXE)
+
+$(TARGET): $(OBJ)
+	$(AR) rcsD $@ $(OBJ)
+	
+$(OUT_DIR)/%.o: $(PROTECTED_FS_PROJECT_ROOT)/%.cpp
+	mkdir -p $(OUT_DIR)/$(TSGX_DIR)
+	mkdir -p $(OUT_DIR)/$(USGX_DIR)
+	$(CXX) $(CXXFLAGS) $(INCLUDE)  -c $< -o $@
+
+$(EXAMPLE_EXE): $(TARGET)
+	$(CXX) -m64 -O2 $(INCLUDE) $(EXAMPLE_SRC) $(TARGET) $(EXAMPLE_DEP_OPTION) -o $(EXAMPLE_EXE) 
+
+.PHONY: clean
+clean:
+	@$(RM) $(OBJ)
+	@$(RM) $(TARGET) 
+	@$(RM) $(EXAMPLE_EXE) 
+	@$(RM) $(EXAMPLE_OUTPUT) 
+
+.PHONY: rebuild
+rebuild: 
+	$(MAKE) clean 
+	$(MAKE) all

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/example/example.c
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/example/example.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "sgx_tprotected_fs.h"
+
+int main() {
+    const char *file_name = "data_file";
+    sgx_key_128bit_t key = {'0', '1', '2', '3', '4', '5', '6', '7',
+                            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+    SGX_FILE* fd = sgx_fopen(file_name, "w", &key);
+    if (fd == NULL) {
+        fprintf(stderr, "create file failed");
+        return -1;
+    }
+
+    int unit_size = 0x10000;
+    unsigned char *buffer = (unsigned char *)malloc(unit_size);
+    if (buffer == NULL) {
+        fprintf(stderr, "malloc buffer failed");
+        sgx_fclose(fd);
+        return -1;
+    }
+    
+    memset(buffer, 0x90, unit_size);
+    
+    
+    for (int i = 0; i < unit_size; i++) {
+        size_t n = sgx_fwrite(buffer, 1, unit_size, fd);
+        if (n != unit_size) {
+            fprintf(stderr, "write file failed: 0x%lx, unit_size: 0x%x, i: 0x%x\n", n, unit_size, i);
+            sgx_fclose(fd);
+            return -1;
+        }
+    }
+
+    sgx_fclose(fd);
+
+    return 0;
+}

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/inc/non_sgx_protected_fs.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/inc/non_sgx_protected_fs.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#ifndef _NON_SGX_PROTECTED_FS_H_
+#define _NON_SGX_PROTECTED_FS_H_
+
+#include "sgx_error.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#define SGX_AESGCM_IV_SIZE              12
+#define SGX_AESGCM_KEY_SIZE             16
+#define SGX_AESGCM_MAC_SIZE             16
+#define SGX_CMAC_KEY_SIZE               16
+#define SGX_CMAC_MAC_SIZE               16
+
+typedef uint8_t aead_128bit_key_t[SGX_AESGCM_KEY_SIZE];
+typedef uint8_t aead_128bit_tag_t[SGX_AESGCM_MAC_SIZE];
+typedef uint8_t cmac_128bit_key_t[SGX_CMAC_KEY_SIZE];
+typedef uint8_t cmac_128bit_tag_t[SGX_CMAC_MAC_SIZE];
+typedef uint8_t sgx_key_128bit_t[16];
+
+typedef aead_128bit_key_t sgx_aes_gcm_128bit_key_t;
+typedef aead_128bit_tag_t sgx_aes_gcm_128bit_tag_t;
+typedef cmac_128bit_tag_t sgx_cmac_128bit_key_t;
+typedef cmac_128bit_tag_t sgx_cmac_128bit_tag_t;
+
+#include <pthread.h>
+#define sgx_thread_mutex_lock pthread_mutex_lock
+#define sgx_thread_mutex_unlock pthread_mutex_unlock
+#define sgx_thread_mutex_init pthread_mutex_init
+#define sgx_thread_mutex_t pthread_mutex_t
+#define sgx_thread_mutex_destroy pthread_mutex_destroy
+
+//defined in sgx_key.h
+#define SGX_KEYID_SIZE    32
+#define SGX_CPUSVN_SIZE   16
+typedef uint16_t                   sgx_isv_svn_t;
+
+typedef struct _sgx_key_id_t
+{
+    uint8_t                        id[SGX_KEYID_SIZE];
+} sgx_key_id_t;
+
+typedef struct _sgx_cpu_svn_t
+{
+    uint8_t                        svn[SGX_CPUSVN_SIZE];
+} sgx_cpu_svn_t;
+
+// defined in sgx_tae_service.h
+#define SGX_MC_UUID_COUNTER_ID_SIZE 3
+#define SGX_MC_UUID_NONCE_SIZE      13
+typedef struct _mc_uuid {
+    uint8_t counter_id[SGX_MC_UUID_COUNTER_ID_SIZE];
+    uint8_t nonce[SGX_MC_UUID_NONCE_SIZE];
+} sgx_mc_uuid_t;
+
+
+// sgx_attributes.h
+typedef struct _attributes_t
+{
+    uint64_t      flags;
+    uint64_t      xfrm;
+} sgx_attributes_t;
+
+
+
+sgx_status_t sgx_rijndael128_cmac_msg(const sgx_cmac_128bit_key_t *p_key, const uint8_t *p_src,
+                                      uint32_t src_len, sgx_cmac_128bit_tag_t *p_mac);
+
+sgx_status_t sgx_rijndael128GCM_encrypt(const sgx_aes_gcm_128bit_key_t *p_key, const uint8_t *p_src, uint32_t src_len,
+                                        uint8_t *p_dst, const uint8_t *p_iv, uint32_t iv_len, const uint8_t *p_aad, uint32_t aad_len,
+                                        sgx_aes_gcm_128bit_tag_t *p_out_mac);
+
+sgx_status_t sgx_rijndael128GCM_decrypt(const sgx_aes_gcm_128bit_key_t *p_key, const uint8_t *p_src,
+                                        uint32_t src_len, uint8_t *p_dst, const uint8_t *p_iv, uint32_t iv_len,
+                                        const uint8_t *p_aad, uint32_t aad_len, const sgx_aes_gcm_128bit_tag_t *p_in_mac);
+
+sgx_status_t read_rand(uint8_t *buf, size_t size);
+#define sgx_read_rand read_rand
+
+int memset_s(void *s, size_t smax, int c, size_t n);
+int consttime_memequal(const void *b1, const void *b2, size_t len);
+
+#endif // _NON_SGX_PROTECTED_FS_H_

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/inc/sgx_error.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/inc/sgx_error.h
@@ -1,0 +1,110 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _SGX_ERROR_H_
+#define _SGX_ERROR_H_
+
+#define SGX_MK_ERROR(x)              (0x00000000|(x))
+
+typedef enum _status_t
+{
+    SGX_SUCCESS                  = SGX_MK_ERROR(0x0000),
+
+    SGX_ERROR_UNEXPECTED         = SGX_MK_ERROR(0x0001),      /* Unexpected error */
+    SGX_ERROR_INVALID_PARAMETER  = SGX_MK_ERROR(0x0002),      /* The parameter is incorrect */
+    SGX_ERROR_OUT_OF_MEMORY      = SGX_MK_ERROR(0x0003),      /* Not enough memory is available to complete this operation */
+    SGX_ERROR_ENCLAVE_LOST       = SGX_MK_ERROR(0x0004),      /* Enclave lost after power transition or used in child process created by linux:fork() */
+    SGX_ERROR_INVALID_STATE      = SGX_MK_ERROR(0x0005),      /* SGX API is invoked in incorrect order or state */
+    SGX_ERROR_FEATURE_NOT_SUPPORTED = SGX_MK_ERROR(0x0008),   /* Feature is not supported on this platform */
+
+
+
+    SGX_ERROR_INVALID_FUNCTION   = SGX_MK_ERROR(0x1001),      /* The ecall/ocall index is invalid */
+    SGX_ERROR_OUT_OF_TCS         = SGX_MK_ERROR(0x1003),      /* The enclave is out of TCS */
+    SGX_ERROR_ENCLAVE_CRASHED    = SGX_MK_ERROR(0x1006),      /* The enclave is crashed */
+    SGX_ERROR_ECALL_NOT_ALLOWED  = SGX_MK_ERROR(0x1007),      /* The ECALL is not allowed at this time, e.g. ecall is blocked by the dynamic entry table, or nested ecall is not allowed during initialization */
+    SGX_ERROR_OCALL_NOT_ALLOWED  = SGX_MK_ERROR(0x1008),      /* The OCALL is not allowed at this time, e.g. ocall is not allowed during exception handling */
+    SGX_ERROR_STACK_OVERRUN      = SGX_MK_ERROR(0x1009),      /* The enclave is running out of stack */
+
+    SGX_ERROR_UNDEFINED_SYMBOL   = SGX_MK_ERROR(0x2000),      /* The enclave image has undefined symbol. */
+    SGX_ERROR_INVALID_ENCLAVE    = SGX_MK_ERROR(0x2001),      /* The enclave image is not correct. */
+    SGX_ERROR_INVALID_ENCLAVE_ID = SGX_MK_ERROR(0x2002),      /* The enclave id is invalid */
+    SGX_ERROR_INVALID_SIGNATURE  = SGX_MK_ERROR(0x2003),      /* The signature is invalid */
+    SGX_ERROR_NDEBUG_ENCLAVE     = SGX_MK_ERROR(0x2004),      /* The enclave is signed as product enclave, and can not be created as debuggable enclave. */
+    SGX_ERROR_OUT_OF_EPC         = SGX_MK_ERROR(0x2005),      /* Not enough EPC is available to load the enclave */
+    SGX_ERROR_NO_DEVICE          = SGX_MK_ERROR(0x2006),      /* Can't open SGX device */
+    SGX_ERROR_MEMORY_MAP_CONFLICT= SGX_MK_ERROR(0x2007),      /* Page mapping failed in driver */
+    SGX_ERROR_INVALID_METADATA   = SGX_MK_ERROR(0x2009),      /* The metadata is incorrect. */
+    SGX_ERROR_DEVICE_BUSY        = SGX_MK_ERROR(0x200c),      /* Device is busy, mostly EINIT failed. */
+    SGX_ERROR_INVALID_VERSION    = SGX_MK_ERROR(0x200d),      /* Metadata version is inconsistent between uRTS and sgx_sign or uRTS is incompatible with current platform. */
+    SGX_ERROR_MODE_INCOMPATIBLE  = SGX_MK_ERROR(0x200e),      /* The target enclave 32/64 bit mode or sim/hw mode is incompatible with the mode of current uRTS. */
+    SGX_ERROR_ENCLAVE_FILE_ACCESS = SGX_MK_ERROR(0x200f),     /* Can't open enclave file. */
+    SGX_ERROR_INVALID_MISC        = SGX_MK_ERROR(0x2010),     /* The MiscSelct/MiscMask settings are not correct.*/
+    SGX_ERROR_INVALID_LAUNCH_TOKEN = SGX_MK_ERROR(0x2011),    /* The launch token is not correct.*/
+
+    SGX_ERROR_MAC_MISMATCH       = SGX_MK_ERROR(0x3001),      /* Indicates verification error for reports, sealed datas, etc */
+    SGX_ERROR_INVALID_ATTRIBUTE  = SGX_MK_ERROR(0x3002),      /* The enclave is not authorized */
+    SGX_ERROR_INVALID_CPUSVN     = SGX_MK_ERROR(0x3003),      /* The cpu svn is beyond platform's cpu svn value */
+    SGX_ERROR_INVALID_ISVSVN     = SGX_MK_ERROR(0x3004),      /* The isv svn is greater than the enclave's isv svn */
+    SGX_ERROR_INVALID_KEYNAME    = SGX_MK_ERROR(0x3005),      /* The key name is an unsupported value */
+
+    SGX_ERROR_SERVICE_UNAVAILABLE       = SGX_MK_ERROR(0x4001),   /* Indicates aesm didn't respond or the requested service is not supported */
+    SGX_ERROR_SERVICE_TIMEOUT           = SGX_MK_ERROR(0x4002),   /* The request to aesm timed out */
+    SGX_ERROR_AE_INVALID_EPIDBLOB       = SGX_MK_ERROR(0x4003),   /* Indicates epid blob verification error */
+    SGX_ERROR_SERVICE_INVALID_PRIVILEGE = SGX_MK_ERROR(0x4004),   /* Enclave has no privilege to get launch token */
+    SGX_ERROR_EPID_MEMBER_REVOKED       = SGX_MK_ERROR(0x4005),   /* The EPID group membership is revoked. */
+    SGX_ERROR_UPDATE_NEEDED             = SGX_MK_ERROR(0x4006),   /* SGX needs to be updated */
+    SGX_ERROR_NETWORK_FAILURE           = SGX_MK_ERROR(0x4007),   /* Network connecting or proxy setting issue is encountered */
+    SGX_ERROR_AE_SESSION_INVALID        = SGX_MK_ERROR(0x4008),   /* Session is invalid or ended by server */
+    SGX_ERROR_BUSY                      = SGX_MK_ERROR(0x400a),   /* The requested service is temporarily not availabe */
+    SGX_ERROR_MC_NOT_FOUND              = SGX_MK_ERROR(0x400c),   /* The Monotonic Counter doesn't exist or has been invalided */
+    SGX_ERROR_MC_NO_ACCESS_RIGHT        = SGX_MK_ERROR(0x400d),   /* Caller doesn't have the access right to specified VMC */
+    SGX_ERROR_MC_USED_UP                = SGX_MK_ERROR(0x400e),   /* Monotonic counters are used out */
+    SGX_ERROR_MC_OVER_QUOTA             = SGX_MK_ERROR(0x400f),   /* Monotonic counters exceeds quota limitation */
+    SGX_ERROR_KDF_MISMATCH              = SGX_MK_ERROR(0x4011),   /* Key derivation function doesn't match during key exchange */
+    SGX_ERROR_UNRECOGNIZED_PLATFORM     = SGX_MK_ERROR(0x4012),   /* EPID Provisioning failed due to platform not recognized by backend server*/
+    SGX_ERROR_UNSUPPORTED_CONFIG        = SGX_MK_ERROR(0x4013),   /* The config for trigging EPID Provisiong or PSE Provisiong&LTP is invalid*/
+
+    SGX_ERROR_NO_PRIVILEGE              = SGX_MK_ERROR(0x5002),   /* Not enough privilege to perform the operation */
+
+    /* SGX Protected Code Loader Error codes*/
+    SGX_ERROR_PCL_ENCRYPTED             = SGX_MK_ERROR(0x6001),   /* trying to encrypt an already encrypted enclave */
+    SGX_ERROR_PCL_NOT_ENCRYPTED         = SGX_MK_ERROR(0x6002),   /* trying to load a plain enclave using sgx_create_encrypted_enclave */
+    SGX_ERROR_PCL_MAC_MISMATCH          = SGX_MK_ERROR(0x6003),   /* section mac result does not match build time mac */
+    SGX_ERROR_PCL_SHA_MISMATCH          = SGX_MK_ERROR(0x6004),   /* Unsealed key MAC does not match MAC of key hardcoded in enclave binary */
+    SGX_ERROR_PCL_GUID_MISMATCH         = SGX_MK_ERROR(0x6005),   /* GUID in sealed blob does not match GUID hardcoded in enclave binary */
+    
+    /* SGX errors are only used in the file API when there is no appropriate EXXX (EINVAL, EIO etc.) error code */
+    SGX_ERROR_FILE_BAD_STATUS               = SGX_MK_ERROR(0x7001),	/* The file is in bad status, run sgx_clearerr to try and fix it */
+    SGX_ERROR_FILE_NO_KEY_ID                = SGX_MK_ERROR(0x7002),	/* The Key ID field is all zeros, can't re-generate the encryption key */
+    SGX_ERROR_FILE_NAME_MISMATCH            = SGX_MK_ERROR(0x7003),	/* The current file name is different then the original file name (not allowed, substitution attack) */
+    SGX_ERROR_FILE_NOT_SGX_FILE             = SGX_MK_ERROR(0x7004), /* The file is not an SGX file */
+    SGX_ERROR_FILE_CANT_OPEN_RECOVERY_FILE  = SGX_MK_ERROR(0x7005),	/* A recovery file can't be opened, so flush operation can't continue (only used when no EXXX is returned)  */
+    SGX_ERROR_FILE_CANT_WRITE_RECOVERY_FILE = SGX_MK_ERROR(0x7006), /* A recovery file can't be written, so flush operation can't continue (only used when no EXXX is returned)  */
+    SGX_ERROR_FILE_RECOVERY_NEEDED          = SGX_MK_ERROR(0x7007),	/* When openeing the file, recovery is needed, but the recovery process failed */
+    SGX_ERROR_FILE_FLUSH_FAILED             = SGX_MK_ERROR(0x7008),	/* fflush operation (to disk) failed (only used when no EXXX is returned) */
+    SGX_ERROR_FILE_CLOSE_FAILED             = SGX_MK_ERROR(0x7009),	/* fclose operation (to disk) failed (only used when no EXXX is returned) */
+
+
+    SGX_ERROR_UNSUPPORTED_ATT_KEY_ID        = SGX_MK_ERROR(0x8001),    /* platform quoting infrastructure does not support the key.*/
+    SGX_ERROR_ATT_KEY_CERTIFICATION_FAILURE = SGX_MK_ERROR(0x8002),    /* Failed to generate and certify the attestation key.*/
+    SGX_ERROR_ATT_KEY_UNINITIALIZED         = SGX_MK_ERROR(0x8003),    /* The platform quoting infrastructure does not have the attestation key available to generate quote.*/
+    SGX_ERROR_INVALID_ATT_KEY_CERT_DATA     = SGX_MK_ERROR(0x8004),    /* TThe data returned by the platform library's sgx_get_quote_config() is invalid.*/
+    SGX_ERROR_PLATFORM_CERT_UNAVAILABLE     = SGX_MK_ERROR(0x8005),    /* The PCK Cert for the platform is not available.*/
+
+    SGX_INTERNAL_ERROR_ENCLAVE_CREATE_INTERRUPTED = SGX_MK_ERROR(0xF001), /* The ioctl for enclave_create unexpectedly failed with EINTR. */ 
+
+} sgx_status_t;
+
+#endif

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/protected_fs_config.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/protected_fs_config.h
@@ -12,8 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod common_setup;
-pub mod kms_test;
-pub mod protected_fs_test;
-pub mod tdfs_test;
-pub mod tms_test;
+#define NON_SGX_PROTECTED_FS

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs.h
@@ -1,0 +1,267 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/**
+* File: sgx_tprotected_fs.h
+* Description:
+*     Interface for file API
+*/
+
+#pragma once
+
+#ifndef _SGX_TPROTECTED_FS_H_
+#define _SGX_TPROTECTED_FS_H_
+
+#include <stddef.h>
+
+#include "protected_fs_config.h"
+
+#ifdef NON_SGX_PROTECTED_FS
+#include <stdint.h>
+typedef uint8_t sgx_key_128bit_t[16];
+#define SGXAPI
+#else
+#include "sgx_defs.h"
+#include "sgx_key.h"
+
+#define FILENAME_MAX  260
+#define FOPEN_MAX     20
+
+#define EOF        (-1)
+
+#define SEEK_SET    0
+#define SEEK_CUR    1
+#define SEEK_END    2
+#endif
+
+#define SGX_FILE void
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* sgx_fopen
+ *  Purpose: open existing protected file (created with previous call to sgc_fopen) or create a new one (see c++ fopen documentation for more details).
+ *
+ *  Parameters:
+ *      filename - [IN] the name of the file to open/create.
+ *      mode - [IN] open mode. only supports 'r' or 'w' or 'a' (one and only one of them must be present), and optionally 'b' and/or '+'.
+ *      key - [IN] encryption key that will be used for the file encryption
+ *      NOTE - the key is actually used as a KDK (key derivation key) and only for the meta-data node, and not used directly for the encryption of any part of the file
+ *             this is important in order to prevent hitting the key wear-out problem, and some other issues with GCM encryptions using the same key
+ *
+ *  Return value:
+ *     SGX_FILE*  - pointer to the newly created file handle, NULL if an error occurred - check errno for the error code.
+*/
+SGX_FILE* SGXAPI sgx_fopen(const char* filename, const char* mode, const sgx_key_128bit_t *key);
+
+
+/* sgx_fopen_auto_key
+*  Purpose: open existing protected file (created with previous call to sgc_fopen_auto_key) or create a new one (see c++ fopen documentation for more details).
+*           this API doesn't require a key from the user, and instead uses the enclave's SEAL key as a KDK for deriving the mete-data encryption keys
+*           using the SEAL key as a KDK, may result losing file access in cases of disaster-recovery or in cases of VM migration in servers
+*           users that any of these scenarious apply to them, are advised to use sgx_fopen, where they can provide their own key and manage the keys provisioning for those scenarious
+*           for further information, please read the SGX SDK manual
+*
+*  Parameters:
+*      filename - [IN] the name of the file to open/create.
+*      mode - [IN] open mode. only supports 'r' or 'w' or 'a' (one and only one of them must be present), and optionally 'b' and/or '+'.
+*
+*  Return value:
+*     SGX_FILE*  - pointer to the newly created file handle, NULL if an error occurred - check errno for the error code.
+*/
+SGX_FILE* SGXAPI sgx_fopen_auto_key(const char* filename, const char* mode);
+
+
+/* sgx_fwrite
+ *  Purpose: write data to a file (see c++ fwrite documentation for more details).
+ *
+ *  Parameters:
+ *      ptr - [IN] pointer to the input data buffer
+ *      size - [IN] size of data block
+ *      count - [IN] count of data blocks to write
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *
+ *  Return value:
+ *     size_t  - number of 'size' blocks written to the file, 0 in case of an error - check sgx_ferror for error code
+*/
+size_t SGXAPI sgx_fwrite(const void* ptr, size_t size, size_t count, SGX_FILE* stream);
+
+
+/* sgx_fread
+ *  Purpose: read data from a file (see c++ fread documentation for more details).
+ *
+ *  Parameters:
+ *      ptr - [OUT] pointer to the output data buffer
+ *      size - [IN] size of data block
+ *      count - [IN] count of data blocks to write
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *
+ *  Return value:
+ *     size_t  - number of 'size' blocks read from the file, 0 in case of an error - check sgx_ferror for error code
+*/
+size_t SGXAPI sgx_fread(void* ptr, size_t size, size_t count, SGX_FILE* stream);
+
+
+/* sgx_ftell
+ *  Purpose: get the current value of the position indicator of the file (see c++ ftell documentation for more details).
+ *
+ *  Parameters:
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *
+ *  Return value:
+ *     int64_t  - the current value of the position indicator, -1 on error - check errno for the error code
+*/
+int64_t SGXAPI sgx_ftell(SGX_FILE* stream);
+
+
+/* sgx_fseek
+ *  Purpose: set the current value of the position indicator of the file (see c++ fseek documentation for more details).
+ *
+ *  Parameters:
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *      offset - [IN] the new required value, relative to the origin parameter
+ *      origin - [IN] the origin from which to calculate the offset (SEEK_SET, SEEK_CUR or SEEK_END)
+ *
+ *  Return value:
+ *     int32_t  - result, 0 on success, -1 in case of an error - check sgx_ferror for error code
+*/
+int32_t SGXAPI sgx_fseek(SGX_FILE* stream, int64_t offset, int origin);
+
+
+/* sgx_fflush
+ *  Purpose: force actual write of all the cached data to the disk (see c++ fflush documentation for more details).
+ *
+ *  Parameters:
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *
+ *  Return value:
+ *     int32_t  - result, 0 on success, 1 in case of an error - check sgx_ferror for error code
+*/
+int32_t SGXAPI sgx_fflush(SGX_FILE* stream);
+
+
+/* sgx_ferror
+ *  Purpose: get the latest operation error code (see c++ ferror documentation for more details).
+ *
+ *  Parameters:
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *
+ *  Return value:
+ *     int32_t  - the error code, 0 means no error, anything else is the latest operation error code
+*/
+int32_t SGXAPI sgx_ferror(SGX_FILE* stream);
+
+
+/* sgx_feof
+ *  Purpose: did the file's position indicator hit the end of the file in a previous read operation (see c++ feof documentation for more details).
+ *
+ *  Parameters:
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *
+ *  Return value:
+ *     int32_t  - 1 - end of file was reached, 0 - end of file wasn't reached
+*/
+int32_t SGXAPI sgx_feof(SGX_FILE* stream);
+
+
+/* sgx_clearerr
+ *  Purpose: try to clear an error in the file status, also clears the end-of-file flag (see c++ clearerr documentation for more details).
+ *           call sgx_ferror or sgx_feof after a call to this function to learn if it was successful or not
+ *
+ *  Parameters:
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *
+ *  Return value:
+ *      none
+*/
+void SGXAPI sgx_clearerr(SGX_FILE* stream);
+
+
+/* sgx_fclose
+ *  Purpose: close an open file handle (see c++ fclose documentation for more details).
+ *           after a call to this function, the handle is invalid even if an error is returned
+ *
+ *  Parameters:
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *
+ *  Return value:
+ *     int32_t  - result, 0 - file was closed successfully, 1 - there were errors during the operation
+*/
+int32_t SGXAPI sgx_fclose(SGX_FILE* stream);
+
+
+/* sgx_remove
+ *  Purpose: delete a file from the file system (see c++ remove documentation for more details).
+ *
+ *  Parameters:
+ *      filename - [IN] the name of the file to remvoe.
+ *
+ *  Return value:
+ *     int32_t  - result, 0 - success, 1 - there was an error, check errno for the error code
+*/
+int32_t SGXAPI sgx_remove(const char* filename);
+
+
+/* sgx_fexport_auto_key
+*  Purpose: export the last key that was used in the encryption of the file.
+*           with this key we can import the file in a different enclave/system
+*           NOTE - 1. in order for this function to work, the file should not be opened in any other process
+*                  2. this function only works with files created with sgx_fopen_auto_key
+*
+*  Parameters:
+*      filename - [IN] the name of the file to export the encryption key from.
+*      key - [OUT] the exported encryption key
+*
+*  Return value:
+*     int32_t  - result, 0 - success, 1 - there was an error, check errno for the error code
+*/
+int32_t SGXAPI sgx_fexport_auto_key(const char* filename, sgx_key_128bit_t *key);
+
+
+/* sgx_fimport_auto_key
+*  Purpose: import a file that was created in a different enclave/system and make it a local file
+*           after this call return successfully, the file can be opened with sgx_fopen_auto_key
+*           NOTE - this function only works with files created with sgx_fopen_auto_key
+*
+*  Parameters:
+*      filename - [IN] the name of the file to be imported.
+*      key - [IN] the encryption key, exported with a call to sgx_fexport_auto_key in the source enclave/system
+*
+*  Return value:
+*     int32_t  - result, 0 - success, 1 - there was an error, check errno for the error code
+*/
+int32_t SGXAPI sgx_fimport_auto_key(const char* filename, const sgx_key_128bit_t *key);
+
+
+/* sgx_fclear_cache
+*  Purpose: scrubs and delete the internal cache used by the file, any changed data is flushed to disk before deletion
+*           Note - only the secrets that were in the cache are deleted, the file structure itself still holds keys and plain file data
+*                  if a user wishes to remove all secrets from memory, he should close the file handle with sgx_fclose
+*
+*  Parameters:
+*      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key
+*
+*  Return value:
+*     int32_t  - result, 0 - success, 1 - there was an error, check errno for the error code
+*/
+int32_t SGXAPI sgx_fclear_cache(SGX_FILE* stream);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _SGX_TPROTECTED_FS_H_

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/Readme.md
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/Readme.md
@@ -1,0 +1,3 @@
+# Note
+
+Please visit our [homepage](https://github.com/baidu/rust-sgx-sdk) for usage. Thanks!

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_crypto.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_crypto.cpp
@@ -1,0 +1,283 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "protected_fs_file.h"
+#ifdef NON_SGX_PROTECTED_FS
+#include "non_sgx_protected_fs.h"
+#else
+#include <tseal_migration_attr.h>
+#include <sgx_utils.h>
+#include <sgx_trts.h>
+#endif
+
+
+#define MASTER_KEY_NAME      "SGX-PROTECTED-FS-MASTER-KEY"
+#define RANDOM_KEY_NAME      "SGX-PROTECTED-FS-RANDOM-KEY"
+#define METADATA_KEY_NAME    "SGX-PROTECTED-FS-METADATA-KEY"
+
+#define MAX_LABEL_LEN 64
+
+typedef struct {
+	uint32_t index;
+	char label[MAX_LABEL_LEN];
+	uint64_t node_number; // context 1
+	union { // context 2
+		sgx_cmac_128bit_tag_t nonce16;
+		sgx_key_id_t nonce32;
+	};
+	uint32_t output_len; // in bits
+} kdf_input_t;
+
+#define MAX_MASTER_KEY_USAGES 65536
+
+bool protected_fs_file::generate_secure_blob(sgx_aes_gcm_128bit_key_t* key, const char* label, uint64_t physical_node_number, sgx_aes_gcm_128bit_tag_t* output)
+{
+	kdf_input_t buf = {0, "", 0, "", 0};
+
+	uint32_t len = (uint32_t)strnlen(label, MAX_LABEL_LEN + 1);
+	if (len > MAX_LABEL_LEN)
+	{
+		last_error = EINVAL;
+		return false;
+	}
+
+	// index
+	// SP800-108:
+	// i - A counter, a binary string of length r that is an input to each iteration of a PRF in counter mode [...].
+	buf.index = 0x01;
+
+	// label
+	// SP800-108:
+	// Label - A string that identifies the purpose for the derived keying material, which is encoded as a binary string. 
+	//         The encoding method for the Label is defined in a larger context, for example, in the protocol that uses a KDF.
+	strncpy(buf.label, label, len);
+
+	// context and nonce
+	// SP800-108: 
+	// Context - A binary string containing the information related to the derived keying material.
+	//           It may include identities of parties who are deriving and / or using the derived keying material and, 
+	//           optionally, a nonce known by the parties who derive the keys.
+	buf.node_number = physical_node_number;
+
+	sgx_status_t status = sgx_read_rand((unsigned char*)&(buf.nonce16), sizeof(sgx_cmac_128bit_tag_t));
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return false;
+	}
+
+	// length of output (128 bits)
+	buf.output_len = 0x80;
+
+	status = sgx_rijndael128_cmac_msg(key, (const uint8_t*)&buf, sizeof(kdf_input_t), output);
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return false;
+	}
+
+	memset_s(&buf, sizeof(kdf_input_t), 0, sizeof(kdf_input_t));
+
+	return true;
+}
+
+
+bool protected_fs_file::generate_secure_blob_from_user_kdk(bool restore)
+{
+	kdf_input_t buf = {0, "", 0, "", 0};
+	sgx_status_t status = SGX_SUCCESS;
+
+	// index
+	// SP800-108:
+	// i - A counter, a binary string of length r that is an input to each iteration of a PRF in counter mode [...].
+	buf.index = 0x01;
+
+	// label
+	// SP800-108:
+	// Label - A string that identifies the purpose for the derived keying material, which is encoded as a binary string. 
+	//         The encoding method for the Label is defined in a larger context, for example, in the protocol that uses a KDF.
+	strncpy(buf.label, METADATA_KEY_NAME, strlen(METADATA_KEY_NAME));
+
+	// context and nonce
+	// SP800-108: 
+	// Context - A binary string containing the information related to the derived keying material.
+	//           It may include identities of parties who are deriving and / or using the derived keying material and, 
+	//           optionally, a nonce known by the parties who derive the keys.
+	buf.node_number = 0;
+
+	// use 32 bytes here just for compatibility with the seal key API
+	if (restore == false)
+	{
+		status = sgx_read_rand((unsigned char*)&(buf.nonce32), sizeof(sgx_key_id_t));
+		if (status != SGX_SUCCESS)
+		{
+			last_error = status;
+			return false;
+		}
+	}
+	else
+	{
+		memcpy(&buf.nonce32, &file_meta_data.plain_part.meta_data_key_id, sizeof(sgx_key_id_t));
+	}
+	
+
+	// length of output (128 bits)
+	buf.output_len = 0x80;
+
+	status = sgx_rijndael128_cmac_msg(&user_kdk_key, (const uint8_t*)&buf, sizeof(kdf_input_t), &cur_key);
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return false;
+	}
+
+	if (restore == false)
+	{
+		memcpy(&file_meta_data.plain_part.meta_data_key_id, &buf.nonce32, sizeof(sgx_key_id_t));
+	}
+
+	memset_s(&buf, sizeof(kdf_input_t), 0, sizeof(kdf_input_t));
+
+	return true;
+}
+
+
+bool protected_fs_file::init_session_master_key()
+{
+	sgx_aes_gcm_128bit_key_t empty_key = {0};
+		
+	if (generate_secure_blob(&empty_key, MASTER_KEY_NAME, 0, (sgx_aes_gcm_128bit_tag_t*)&session_master_key) == false)
+		return false;
+
+	master_key_count = 0;
+
+	return true;
+}
+
+
+bool protected_fs_file::derive_random_node_key(uint64_t physical_node_number)
+{
+	if (master_key_count++ > MAX_MASTER_KEY_USAGES)
+	{
+		if (init_session_master_key() == false)
+			return false;
+	}
+
+	if (generate_secure_blob(&session_master_key, RANDOM_KEY_NAME, physical_node_number, (sgx_aes_gcm_128bit_tag_t*)&cur_key) == false)
+		return false;
+
+	return true;
+}
+
+
+bool protected_fs_file::generate_random_meta_data_key()
+{
+	if (use_user_kdk_key == 1)
+	{
+		return generate_secure_blob_from_user_kdk(false);
+	}
+
+#ifdef NON_SGX_PROTECTED_FS
+	assert(0);
+	return false;
+#else
+	// derive a random key from the enclave sealing key	
+	sgx_key_request_t key_request;
+	memset(&key_request, 0, sizeof(sgx_key_request_t)); 
+		
+	key_request.key_name = SGX_KEYSELECT_SEAL;
+	key_request.key_policy = SGX_KEYPOLICY_MRSIGNER;
+
+	memcpy(&key_request.cpu_svn, &report.body.cpu_svn, sizeof(sgx_cpu_svn_t));
+	memcpy(&key_request.isv_svn, &report.body.isv_svn, sizeof(sgx_isv_svn_t));
+
+    key_request.attribute_mask.flags = TSEAL_DEFAULT_FLAGSMASK;
+    key_request.attribute_mask.xfrm = 0x0;
+
+	key_request.misc_mask = TSEAL_DEFAULT_MISCMASK;
+		
+	sgx_status_t status = sgx_read_rand((unsigned char*)&key_request.key_id, sizeof(sgx_key_id_t));
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return false;
+	}
+	
+	status = sgx_get_key(&key_request, &cur_key);
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return false;
+	}
+
+	// save the key_id and svn's so the key can be restored even if svn's are updated
+	memcpy(&file_meta_data.plain_part.meta_data_key_id, &key_request.key_id, sizeof(sgx_key_id_t)); // save this value in the meta data
+	memcpy(&file_meta_data.plain_part.cpu_svn, &key_request.cpu_svn, sizeof(sgx_cpu_svn_t));
+	memcpy(&file_meta_data.plain_part.isv_svn, &key_request.isv_svn, sizeof(sgx_isv_svn_t));
+	return true;
+#endif
+}
+
+
+bool protected_fs_file::restore_current_meta_data_key(const sgx_aes_gcm_128bit_key_t* import_key)
+{
+	if (import_key != NULL)
+	{		
+		memcpy(&cur_key, import_key, sizeof(sgx_aes_gcm_128bit_key_t));
+		return true;
+	}
+
+	if (use_user_kdk_key == 1)
+	{
+		return generate_secure_blob_from_user_kdk(true);
+	}
+
+#ifdef NON_SGX_PROTECTED_FS
+	assert(0);
+	return false;
+#else
+	sgx_key_id_t empty_key_id = {0};
+	if (consttime_memequal(&file_meta_data.plain_part.meta_data_key_id, &empty_key_id, sizeof(sgx_key_id_t)) == 1)
+	{
+		last_error = SGX_ERROR_FILE_NO_KEY_ID;
+		return false;
+	}
+
+	sgx_key_request_t key_request;
+	memset(&key_request, 0, sizeof(sgx_key_request_t));
+
+	key_request.key_name = SGX_KEYSELECT_SEAL;
+	key_request.key_policy = SGX_KEYPOLICY_MRSIGNER;
+
+	key_request.attribute_mask.flags = TSEAL_DEFAULT_FLAGSMASK;
+    key_request.attribute_mask.xfrm = 0x0;
+
+	key_request.misc_mask = TSEAL_DEFAULT_MISCMASK;
+
+	memcpy(&key_request.cpu_svn, &file_meta_data.plain_part.cpu_svn, sizeof(sgx_cpu_svn_t));
+	memcpy(&key_request.isv_svn, &file_meta_data.plain_part.isv_svn, sizeof(sgx_isv_svn_t));
+	memcpy(&key_request.key_id, &file_meta_data.plain_part.meta_data_key_id, sizeof(sgx_key_id_t));
+
+	sgx_status_t status = sgx_get_key(&key_request, &cur_key);
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return false;
+	}
+
+	return true;
+#endif
+}
+
+

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_flush.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_flush.cpp
@@ -1,0 +1,619 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "protected_fs_config.h"
+
+#include "sgx_tprotected_fs.h"
+#include "sgx_tprotected_fs_t.h"
+#include "protected_fs_file.h"
+#include "tprotected_fs.h"
+
+#ifdef NON_SGX_PROTECTED_FS
+#include "non_sgx_protected_fs.h"
+#else
+#include <sgx_trts.h>
+#endif
+
+bool protected_fs_file::flush(/*bool mc*/)
+{
+	bool result = false;
+
+	int32_t result32 = sgx_thread_mutex_lock(&mutex);
+	if (result32 != 0)
+	{
+		last_error = result32;
+		file_status = SGX_FILE_STATUS_MEMORY_CORRUPTED;
+		return false;
+	}
+
+	if (file_status != SGX_FILE_STATUS_OK)
+	{
+		last_error = SGX_ERROR_FILE_BAD_STATUS;
+		sgx_thread_mutex_unlock(&mutex);
+		return false;
+	}
+	
+	result = internal_flush(/*mc,*/ true);
+	if (result == false)
+	{
+		assert(file_status != SGX_FILE_STATUS_OK);
+		if (file_status == SGX_FILE_STATUS_OK)
+			file_status = SGX_FILE_STATUS_FLUSH_ERROR; // for release set this anyway
+	}
+
+	sgx_thread_mutex_unlock(&mutex);
+
+	return result;
+}
+
+
+bool protected_fs_file::internal_flush(/*bool mc,*/ bool flush_to_disk)
+{
+	if (need_writing == false) // no changes at all
+		return true;
+
+/*
+	if (mc == true && encrypted_part_plain.mc_value > (UINT_MAX-2))
+	{
+		last_error = SGX_ERROR_FILE_MONOTONIC_COUNTER_AT_MAX;
+		return false;
+	}
+*/
+	if (encrypted_part_plain.size > MD_USER_DATA_SIZE && root_mht.need_writing == true) // otherwise it's just one write - the meta-data node
+	{
+		if (_RECOVERY_HOOK_(0) || write_recovery_file() != true)
+		{
+			file_status = SGX_FILE_STATUS_FLUSH_ERROR;
+			return false;
+		}
+
+		if (_RECOVERY_HOOK_(1) || set_update_flag(flush_to_disk) != true)
+		{
+			file_status = SGX_FILE_STATUS_FLUSH_ERROR;
+			return false;
+		}
+
+		if (_RECOVERY_HOOK_(2) || update_all_data_and_mht_nodes() != true)
+		{
+			clear_update_flag();
+			file_status = SGX_FILE_STATUS_CRYPTO_ERROR; // this is something that shouldn't happen, can't fix this...
+			return false;
+		}
+	}
+
+/*
+	sgx_status_t status;
+
+	if (mc == true)
+	{
+		// increase monotonic counter local value - only if everything is ok, we will increase the real counter
+		if (encrypted_part_plain.mc_value == 0)
+		{
+			// no monotonic counter so far, need to create a new one
+			status = sgx_create_monotonic_counter(&encrypted_part_plain.mc_uuid, &encrypted_part_plain.mc_value);
+			if (status != SGX_SUCCESS)
+			{
+				clear_update_flag();
+				file_status = SGX_FILE_STATUS_FLUSH_ERROR;
+				last_error = status;
+				return false;
+			}
+		}
+		encrypted_part_plain.mc_value++;
+	}
+*/
+	if (_RECOVERY_HOOK_(3) || update_meta_data_node() != true)
+	{
+		clear_update_flag();
+		/*
+		if (mc == true)
+			encrypted_part_plain.mc_value--; // don't have to do this as the file cannot be fixed, but doing it anyway to prevent future errors
+		*/
+		file_status = SGX_FILE_STATUS_CRYPTO_ERROR; // this is something that shouldn't happen, can't fix this...
+		return false;
+	}
+
+	if (_RECOVERY_HOOK_(4) || write_all_changes_to_disk(flush_to_disk) != true)
+	{
+		//if (mc == false)
+			file_status = SGX_FILE_STATUS_WRITE_TO_DISK_FAILED; // special case, need only to repeat write_all_changes_to_disk in order to repair it
+		//else
+			//file_status = SGX_FILE_STATUS_WRITE_TO_DISK_FAILED_NEED_MC; // special case, need to repeat write_all_changes_to_disk AND increase the monotonic counter in order to repair it
+
+		return false;
+	}
+
+	need_writing = false;
+
+/* this is causing problems when we delete and create the file rapidly
+   we will just leave the file, and re-write it every time
+   u_sgxprotectedfs_recovery_file_open opens it with 'w' so it is truncated
+	if (encrypted_part_plain.size > MD_USER_DATA_SIZE)
+	{
+		erase_recovery_file();
+	}
+*/
+/*
+	if (mc == true)
+	{
+		uint32_t mc_value;
+		status = sgx_increment_monotonic_counter(&encrypted_part_plain.mc_uuid, &mc_value);
+		if (status != SGX_SUCCESS)
+		{
+			file_status = SGX_FILE_STATUS_MC_NOT_INCREMENTED; // special case - need only to increase the MC in order to repair it
+			last_error = status;
+			return false;
+		}
+		assert(mc_value == encrypted_part_plain.mc_value);
+	}
+*/
+	return true;
+}
+
+
+bool protected_fs_file::write_recovery_file()
+{
+#ifdef NON_SGX_PROTECTED_FS
+	FILE* recovery_file = NULL;
+#else
+	void* recovery_file = NULL;
+#endif
+	sgx_status_t status = SGX_SUCCESS;
+	uint8_t result = 0;
+	int32_t result32 = 0;
+
+#ifdef NON_SGX_PROTECTED_FS
+	recovery_file = u_sgxprotectedfs_recovery_file_open(recovery_filename);
+#else
+	status = u_sgxprotectedfs_recovery_file_open(&recovery_file, recovery_filename);
+#endif
+	if (status != SGX_SUCCESS || recovery_file == NULL)
+	{
+		last_error = status != SGX_SUCCESS ? status : SGX_ERROR_FILE_CANT_OPEN_RECOVERY_FILE;
+		return false;
+	}
+
+	void* data = NULL;
+	recovery_node_t* recovery_node = NULL;
+
+	for (data = cache.get_first() ; data != NULL ; data = cache.get_next())
+	{
+		if (((file_data_node_t*)data)->type == FILE_DATA_NODE_TYPE) // type is in the same offset in both node types
+		{
+			file_data_node_t* file_data_node = (file_data_node_t*)data;
+			if (file_data_node->need_writing == false || file_data_node->new_node == true)
+				continue;
+
+			recovery_node = &file_data_node->recovery_node;
+		}
+		else
+		{
+			file_mht_node_t* file_mht_node = (file_mht_node_t*)data;
+			assert(file_mht_node->type == FILE_MHT_NODE_TYPE);
+			if (file_mht_node->need_writing == false || file_mht_node->new_node == true)
+				continue;
+
+			recovery_node = &file_mht_node->recovery_node;
+		}
+
+#ifdef NON_SGX_PROTECTED_FS
+		result = u_sgxprotectedfs_fwrite_recovery_node(recovery_file, (uint8_t*)recovery_node, sizeof(recovery_node_t));
+#else
+		status = u_sgxprotectedfs_fwrite_recovery_node(&result, recovery_file, (uint8_t*)recovery_node, sizeof(recovery_node_t));
+#endif
+		if (status != SGX_SUCCESS || result != 0)
+		{
+#ifdef NON_SGX_PROTECTED_FS
+			result32 = u_sgxprotectedfs_fclose(recovery_file);
+#else
+			u_sgxprotectedfs_fclose(&result32, recovery_file);
+#endif
+			last_error = status != SGX_SUCCESS ? status : SGX_ERROR_FILE_CANT_WRITE_RECOVERY_FILE;
+#ifdef NON_SGX_PROTECTED_FS
+			result32 = u_sgxprotectedfs_remove(recovery_filename);
+#else
+			u_sgxprotectedfs_remove(&result32, recovery_filename);
+#endif
+			last_error = status != SGX_SUCCESS ? status : SGX_ERROR_FILE_CANT_WRITE_RECOVERY_FILE;
+			return false;
+		}
+	}
+
+	if (root_mht.need_writing == true && root_mht.new_node == false)
+	{
+#ifdef NON_SGX_PROTECTED_FS
+		result = u_sgxprotectedfs_fwrite_recovery_node(recovery_file, (uint8_t*)&root_mht.recovery_node, sizeof(recovery_node_t));
+#else
+		status = u_sgxprotectedfs_fwrite_recovery_node(&result, recovery_file, (uint8_t*)&root_mht.recovery_node, sizeof(recovery_node_t));
+#endif
+		if (status != SGX_SUCCESS || result != 0)
+		{
+#ifdef NON_SGX_PROTECTED_FS
+			result32 = u_sgxprotectedfs_fclose(recovery_file);
+			result32 = u_sgxprotectedfs_remove(recovery_filename);
+#else
+			u_sgxprotectedfs_fclose(&result32, recovery_file);
+			u_sgxprotectedfs_remove(&result32, recovery_filename);
+#endif
+			last_error = status != SGX_SUCCESS ? status : SGX_ERROR_FILE_CANT_WRITE_RECOVERY_FILE;
+			return false;
+		}
+	}
+
+#ifdef NON_SGX_PROTECTED_FS
+	result = u_sgxprotectedfs_fwrite_recovery_node(recovery_file, (uint8_t*)&meta_data_recovery_node, sizeof(recovery_node_t));
+#else
+	status = u_sgxprotectedfs_fwrite_recovery_node(&result, recovery_file, (uint8_t*)&meta_data_recovery_node, sizeof(recovery_node_t));
+#endif
+	if (status != SGX_SUCCESS || result != 0)
+	{
+#ifdef NON_SGX_PROTECTED_FS
+		result32 = u_sgxprotectedfs_fclose(recovery_file);
+		result32 = u_sgxprotectedfs_remove(recovery_filename);
+#else
+		u_sgxprotectedfs_fclose(&result32, recovery_file);
+		u_sgxprotectedfs_remove(&result32, recovery_filename);
+#endif
+		last_error = status != SGX_SUCCESS ? status : SGX_ERROR_FILE_CANT_WRITE_RECOVERY_FILE;
+		return false;
+	}
+
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_fclose(recovery_file); // TODO - check result
+#else
+	u_sgxprotectedfs_fclose(&result32, recovery_file); // TODO - check result
+#endif
+
+	return true;
+}
+
+
+bool protected_fs_file::set_update_flag(bool flush_to_disk)
+{
+	sgx_status_t status = SGX_SUCCESS;
+	uint8_t result;
+	int32_t result32;
+
+	file_meta_data.plain_part.update_flag = 1;
+
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_fwrite_node(file, 0, (uint8_t*)&file_meta_data, NODE_SIZE);
+#else
+	status = u_sgxprotectedfs_fwrite_node(&result32, file, 0, (uint8_t*)&file_meta_data, NODE_SIZE);
+#endif
+	file_meta_data.plain_part.update_flag = 0; // turn it off in memory. at the end of the flush, when we'll write the meta-data to disk, this flag will also be cleared there.
+	if (status != SGX_SUCCESS || result32 != 0)
+	{
+		last_error = (status != SGX_SUCCESS) ? status : 
+					 (result32 != -1) ? result32 : EIO;
+		return false;
+	}
+
+	if (flush_to_disk == true)
+	{
+#ifdef NON_SGX_PROTECTED_FS
+		result = u_sgxprotectedfs_fflush(file);
+#else
+		status = u_sgxprotectedfs_fflush(&result, file);
+#endif
+		if (status != SGX_SUCCESS || result != 0)
+		{
+			last_error = status != SGX_SUCCESS ? status : SGX_ERROR_FILE_FLUSH_FAILED;
+#ifdef NON_SGX_PROTECTED_FS
+			result32 = u_sgxprotectedfs_fwrite_node(file, 0, (uint8_t*)&file_meta_data, NODE_SIZE); // try to clear the update flag, in the OS cache at least...
+#else
+			u_sgxprotectedfs_fwrite_node(&result32, file, 0, (uint8_t*)&file_meta_data, NODE_SIZE); // try to clear the update flag, in the OS cache at least...
+#endif
+			return false;
+		}
+
+	}
+
+	return true;
+}
+
+
+// this function is called if we had an error after we updated the update flag
+// in normal flow, the flag is cleared when the meta-data is written to disk
+void protected_fs_file::clear_update_flag()
+{
+	uint8_t result;
+	int32_t result32;
+
+	if (_RECOVERY_HOOK_(3))
+		return;
+	assert(file_meta_data.plain_part.update_flag == 0);
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_fwrite_node(file, 0, (uint8_t*)&file_meta_data, NODE_SIZE);
+	result = u_sgxprotectedfs_fflush(file);
+#else
+	u_sgxprotectedfs_fwrite_node(&result32, file, 0, (uint8_t*)&file_meta_data, NODE_SIZE);
+	u_sgxprotectedfs_fflush(&result, file);
+#endif
+}
+
+
+// sort function, we need the mht nodes sorted before we start to update their gmac's
+bool mht_order(const file_mht_node_t* first, const file_mht_node_t* second)
+{// higher (lower tree level) node number first
+	return first->mht_node_number > second->mht_node_number;
+}
+
+
+bool protected_fs_file::update_all_data_and_mht_nodes()
+{
+	std::list<file_mht_node_t*> mht_list;
+	std::list<file_mht_node_t*>::iterator mht_list_it;
+	file_mht_node_t* file_mht_node;
+	sgx_status_t status;
+	void* data = cache.get_first();
+
+	// 1. encrypt the changed data
+	// 2. set the IV+GMAC in the parent MHT
+	// [3. set the need_writing flag for all the parents]
+	while (data != NULL)
+	{
+		if (((file_data_node_t*)data)->type == FILE_DATA_NODE_TYPE) // type is in the same offset in both node types
+		{
+			file_data_node_t* data_node = (file_data_node_t*)data;
+
+			if (data_node->need_writing == true)
+			{
+				if (derive_random_node_key(data_node->physical_node_number) == false)
+					return false;
+
+				gcm_crypto_data_t* gcm_crypto_data = &data_node->parent->plain.data_nodes_crypto[data_node->data_node_number % ATTACHED_DATA_NODES_COUNT];
+
+				// encrypt the data, this also saves the gmac of the operation in the mht crypto node
+				status = sgx_rijndael128GCM_encrypt(&cur_key, data_node->plain.data, NODE_SIZE, data_node->encrypted.cipher, 
+													empty_iv, SGX_AESGCM_IV_SIZE, NULL, 0, &gcm_crypto_data->gmac);
+				if (status != SGX_SUCCESS)
+				{
+					last_error = status;
+					return false;
+				}
+
+				memcpy(gcm_crypto_data->key, cur_key, sizeof(sgx_aes_gcm_128bit_key_t)); // save the key used for this encryption
+
+				file_mht_node = data_node->parent;
+				// this loop should do nothing, add it here just to be safe
+				while (file_mht_node->mht_node_number != 0)
+				{
+					assert(file_mht_node->need_writing == true);
+					file_mht_node->need_writing = true; // just in case, for release
+					file_mht_node = file_mht_node->parent;
+				}
+			}
+		}
+		data = cache.get_next();
+	}
+
+	// add all the mht nodes that needs writing to a list
+	data = cache.get_first();
+	while (data != NULL)
+	{
+		if (((file_mht_node_t*)data)->type == FILE_MHT_NODE_TYPE) // type is in the same offset in both node types
+		{
+			file_mht_node = (file_mht_node_t*)data;
+
+			if (file_mht_node->need_writing == true)
+				mht_list.push_front(file_mht_node);
+		}
+
+		data = cache.get_next();
+	}
+
+	// sort the list from the last node to the first (bottom layers first)
+	mht_list.sort(mht_order);
+
+	// update the gmacs in the parents
+	while ((mht_list_it = mht_list.begin()) != mht_list.end())
+	{
+		file_mht_node = *mht_list_it;
+
+		gcm_crypto_data_t* gcm_crypto_data = &file_mht_node->parent->plain.mht_nodes_crypto[(file_mht_node->mht_node_number - 1) % CHILD_MHT_NODES_COUNT];
+
+		if (derive_random_node_key(file_mht_node->physical_node_number) == false)
+		{
+			mht_list.clear();
+			return false;
+		}
+
+		status = sgx_rijndael128GCM_encrypt(&cur_key, (const uint8_t*)&file_mht_node->plain, NODE_SIZE, file_mht_node->encrypted.cipher, 
+											empty_iv, SGX_AESGCM_IV_SIZE, NULL, 0, &gcm_crypto_data->gmac);
+		if (status != SGX_SUCCESS)
+		{
+			mht_list.clear();
+			last_error = status;
+			return false;
+		}
+
+		memcpy(gcm_crypto_data->key, cur_key, sizeof(sgx_aes_gcm_128bit_key_t)); // save the key used for this gmac
+
+		mht_list.pop_front();
+	}
+
+	// update mht root gmac in the meta data node
+	if (derive_random_node_key(root_mht.physical_node_number) == false)
+		return false;
+
+	status = sgx_rijndael128GCM_encrypt(&cur_key, (const uint8_t*)&root_mht.plain, NODE_SIZE, root_mht.encrypted.cipher, 
+										empty_iv, SGX_AESGCM_IV_SIZE, NULL, 0, &encrypted_part_plain.mht_gmac);
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return false;
+	}
+
+	memcpy(&encrypted_part_plain.mht_key, cur_key, sizeof(sgx_aes_gcm_128bit_key_t)); // save the key used for this gmac
+
+	return true;
+}
+
+
+bool protected_fs_file::update_meta_data_node()
+{
+	sgx_status_t status;
+	
+	// randomize a new key, saves the key _id_ in the meta data plain part
+	if (generate_random_meta_data_key() != true)
+	{
+		// last error already set
+		return false;
+	}
+		
+	// encrypt meta data encrypted part, also updates the gmac in the meta data plain part
+	status = sgx_rijndael128GCM_encrypt(&cur_key, 
+										(const uint8_t*)&encrypted_part_plain, sizeof(meta_data_encrypted_t), (uint8_t*)&file_meta_data.encrypted_part, 
+										empty_iv, SGX_AESGCM_IV_SIZE, 
+										NULL, 0, 
+										&file_meta_data.plain_part.meta_data_gmac);
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return false;
+	}
+
+	return true;
+}
+
+
+bool protected_fs_file::write_all_changes_to_disk(bool flush_to_disk)
+{
+	uint8_t result;
+	int32_t result32;
+	sgx_status_t status = SGX_SUCCESS;
+
+	if (encrypted_part_plain.size > MD_USER_DATA_SIZE && root_mht.need_writing == true)
+	{
+		void* data = NULL;
+		uint8_t* data_to_write;
+		uint64_t node_number;
+		file_data_node_t* file_data_node;
+		file_mht_node_t* file_mht_node;
+
+		for (data = cache.get_first() ; data != NULL ; data = cache.get_next())
+		{
+			file_data_node = NULL;
+			file_mht_node = NULL;
+
+			if (((file_data_node_t*)data)->type == FILE_DATA_NODE_TYPE) // type is in the same offset in both node types
+			{
+				file_data_node = (file_data_node_t*)data;
+				if (file_data_node->need_writing == false)
+					continue;
+
+				data_to_write = (uint8_t*)&file_data_node->encrypted;
+				node_number = file_data_node->physical_node_number;
+			}
+			else
+			{
+				file_mht_node = (file_mht_node_t*)data;
+				assert(file_mht_node->type == FILE_MHT_NODE_TYPE);
+				if (file_mht_node->need_writing == false)
+					continue;
+
+				data_to_write = (uint8_t*)&file_mht_node->encrypted;
+				node_number = file_mht_node->physical_node_number;
+			}
+
+#ifdef NON_SGX_PROTECTED_FS
+			result32 = u_sgxprotectedfs_fwrite_node(file, node_number, data_to_write, NODE_SIZE);
+#else
+			status = u_sgxprotectedfs_fwrite_node(&result32, file, node_number, data_to_write, NODE_SIZE);
+#endif
+			if (status != SGX_SUCCESS || result32 != 0)
+			{
+				last_error = (status != SGX_SUCCESS) ? status : 
+							 (result32 != -1) ? result32 : EIO;
+				return false;
+			}
+
+			// data written - clear the need_writing and the new_node flags (for future transactions, this node it no longer 'new' and should be written to recovery file)
+			if (file_data_node != NULL)
+			{
+				file_data_node->need_writing = false;
+				file_data_node->new_node = false;
+			}
+			else
+			{
+				file_mht_node->need_writing = false;
+				file_mht_node->new_node = false;
+			}
+
+		}
+
+#ifdef NON_SGX_PROTECTED_FS
+		result32 = u_sgxprotectedfs_fwrite_node(file, 1, (uint8_t*)&root_mht.encrypted, NODE_SIZE);
+#else
+		status = u_sgxprotectedfs_fwrite_node(&result32, file, 1, (uint8_t*)&root_mht.encrypted, NODE_SIZE);
+#endif
+
+		if (status != SGX_SUCCESS || result32 != 0)
+		{
+			last_error = (status != SGX_SUCCESS) ? status : 
+						 (result32 != -1) ? result32 : EIO;
+			return false;
+		}
+		root_mht.need_writing = false;
+		root_mht.new_node = false;
+	}
+
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_fwrite_node(file, 0, (uint8_t*)&file_meta_data, NODE_SIZE);
+#else
+	status = u_sgxprotectedfs_fwrite_node(&result32, file, 0, (uint8_t*)&file_meta_data, NODE_SIZE);
+#endif
+	if (status != SGX_SUCCESS || result32 != 0)
+	{
+		last_error = (status != SGX_SUCCESS) ? status : 
+					 (result32 != -1) ? result32 : EIO;
+		return false;
+	}
+
+	if (flush_to_disk == true)
+	{
+#ifdef NON_SGX_PROTECTED_FS
+		result = u_sgxprotectedfs_fflush(file);
+#else
+		status = u_sgxprotectedfs_fflush(&result, file);
+#endif
+		if (status != SGX_SUCCESS || result != 0)
+		{
+			last_error = status != SGX_SUCCESS ? status : SGX_ERROR_FILE_FLUSH_FAILED;
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+void protected_fs_file::erase_recovery_file()
+{
+	sgx_status_t status;
+	int32_t result32;
+
+	if (recovery_filename[0] == '\0') // not initialized yet
+		return;
+
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_remove(recovery_filename);
+#else
+	status = u_sgxprotectedfs_remove(&result32, recovery_filename);
+#endif	
+	(void)status; // don't care if it succeeded or failed...just remove the warning
+}
+
+

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_init.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_init.cpp
@@ -1,0 +1,695 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "protected_fs_config.h"
+
+#include "sgx_tprotected_fs.h"
+#include "sgx_tprotected_fs_t.h"
+#include "protected_fs_file.h"
+
+#ifdef NON_SGX_PROTECTED_FS
+#include "non_sgx_protected_fs.h"
+#else
+#include <sgx_utils.h>
+#endif
+
+// remove the file path if it's there, leave only the filename, null terminated
+bool protected_fs_file::cleanup_filename(const char* src, char* dest)
+{
+	const char* p = src;
+	const char* name = src;
+
+	while ((*p) != '\0')
+	{
+		if ((*p) == '\\' || (*p) == '/')
+			name = p+1;
+		p++;
+	}
+
+	if (strnlen(name, FILENAME_MAX_LEN) >= FILENAME_MAX_LEN-1)
+	{
+		last_error = ENAMETOOLONG;
+		return false;
+	}
+
+	strncpy(dest, name, FILENAME_MAX_LEN-1);
+	dest[FILENAME_MAX_LEN-1] = '\0';
+
+	if (strnlen(dest, 1) == 0)
+	{
+		last_error = EINVAL;
+		return false;
+	}
+
+	return true;
+}
+
+
+protected_fs_file::protected_fs_file(const char* filename, const char* mode, const sgx_aes_gcm_128bit_key_t* import_key, const sgx_aes_gcm_128bit_key_t* kdk_key)
+{
+	sgx_status_t status = SGX_SUCCESS;
+	uint8_t result = 0;
+	int32_t result32 = 0;
+	
+	init_fields();
+
+	if (filename == NULL || mode == NULL || 
+		strnlen(filename, 1) == 0 || strnlen(mode, 1) == 0)
+	{
+		last_error = EINVAL;
+		return;
+	}
+
+	if (strnlen(filename, FULLNAME_MAX_LEN) >= FULLNAME_MAX_LEN - 1)
+	{
+		last_error = ENAMETOOLONG;
+		return;
+	}
+
+	if (import_key != NULL && kdk_key != NULL)
+	{// import key is used only with auto generated keys
+		last_error = EINVAL;
+		return;
+	}
+
+#ifndef NON_SGX_PROTECTED_FS
+	status = sgx_create_report(NULL, NULL, &report);
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return;
+	}
+#endif
+
+	result32 = sgx_thread_mutex_init(&mutex, NULL);
+	if (result32 != 0)
+	{
+		last_error = result32;
+		return;
+	}
+
+	if (init_session_master_key() == false) 
+		// last_error already set
+		return;
+
+	if (kdk_key != NULL)
+	{
+		// for new file, this value will later be saved in the meta data plain part (init_new_file)
+		// for existing file, we will later compare this value with the value from the file (init_existing_file)
+		use_user_kdk_key = 1; 
+		memcpy(user_kdk_key, kdk_key, sizeof(sgx_aes_gcm_128bit_key_t));
+	}
+	
+	// get the clean file name (original name might be clean or with relative path or with absolute path...)
+	char clean_filename[FILENAME_MAX_LEN];
+	if (cleanup_filename(filename, clean_filename) == false)
+		// last_error already set
+		return;
+	
+	if (import_key != NULL)
+	{// verify the key is not empty - note from SAFE review
+		sgx_aes_gcm_128bit_key_t empty_aes_key = {0};
+		if (consttime_memequal(import_key, &empty_aes_key, sizeof(sgx_aes_gcm_128bit_key_t)) == 1)
+		{
+			last_error = EINVAL;
+			return;
+		}
+	}
+
+	if (parse_mode(mode) == false)
+	{
+		last_error = EINVAL;
+		return;
+	}
+#ifdef NON_SGX_PROTECTED_FS
+	result = u_sgxprotectedfs_check_if_file_exists(filename); // if result == 1 --> file exists
+#else
+	status = u_sgxprotectedfs_check_if_file_exists(&result, filename); // if result == 1 --> file exists
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return;
+	}
+#endif
+
+	if (open_mode.write == 1 && result == 1)
+	{// try to delete existing file
+		int32_t saved_errno = 0;
+
+		result32 = remove(filename);
+		if (result32 != 0)
+		{
+			// either can't delete or the file was already deleted by someone else
+			saved_errno = errno;
+			errno = 0;
+		}
+
+		// re-check
+#ifdef NON_SGX_PROTECTED_FS
+		result = u_sgxprotectedfs_check_if_file_exists(filename);
+		if (result == 1) {
+			return;
+		}
+#else
+		status = u_sgxprotectedfs_check_if_file_exists(&result, filename);
+		if (status != SGX_SUCCESS || result == 1)
+		{
+			last_error = (status != SGX_SUCCESS) ? status :
+						 (saved_errno != 0) ? saved_errno : EACCES;
+			return;
+		}
+#endif
+	}
+
+	if (open_mode.read == 1 && result == 0)
+	{// file must exists
+		last_error = ENOENT;
+		return;
+	}
+
+	if (import_key != NULL && result == 0)
+	{// file must exists - otherwise the user key is not used
+		last_error = ENOENT;
+		return;
+	}
+
+	// now open the file
+	read_only = (open_mode.read == 1 && open_mode.update == 0); // read only files can be opened simultaneously by many enclaves
+
+	do {
+#ifdef NON_SGX_PROTECTED_FS
+		file = (FILE *)u_sgxprotectedfs_exclusive_file_open(filename, read_only, &real_file_size, &result32);
+		if (file == NULL)
+		{
+			last_error = (result32 != 0) ? result32 : EACCES;
+			break;
+		}
+#else
+		status = u_sgxprotectedfs_exclusive_file_open(&file, filename, read_only, &real_file_size, &result32);
+		if (status != SGX_SUCCESS || file == NULL)
+		{
+			last_error = (status != SGX_SUCCESS) ? status :
+					     (result32 != 0) ? result32 : EACCES;
+			break;
+		}
+#endif
+
+		if (real_file_size < 0)
+		{
+			last_error = EINVAL;
+			break;
+		}
+
+		if (real_file_size % NODE_SIZE != 0)
+		{
+			last_error = SGX_ERROR_FILE_NOT_SGX_FILE;
+			break;
+		}
+		
+		strncpy(recovery_filename, filename, FULLNAME_MAX_LEN - 1); // copy full file name
+		recovery_filename[FULLNAME_MAX_LEN - 1] = '\0'; // just to be safe
+		size_t full_name_len = strnlen(recovery_filename, RECOVERY_FILE_MAX_LEN);
+		strncpy(&recovery_filename[full_name_len], "_recovery", 10);
+
+		if (real_file_size > 0)
+		{// existing file
+			if (open_mode.write == 1) // redundant check, just in case
+			{
+				last_error = EACCES;
+				break;
+			}
+
+			if (init_existing_file(filename, clean_filename, import_key) == false)
+				break;
+				
+			if (open_mode.append == 1 && open_mode.update == 0)
+				offset = encrypted_part_plain.size;
+		}
+		else
+		{// new file
+			if (init_new_file(clean_filename) == false)
+				break;
+		}
+
+		file_status = SGX_FILE_STATUS_OK;
+
+	} while(0);
+
+	if (file_status != SGX_FILE_STATUS_OK)
+	{
+		if (file != NULL)
+		{
+#ifdef NON_SGX_PROTECTED_FS
+			result32 = u_sgxprotectedfs_fclose(file); // we don't care about the result
+#else
+			u_sgxprotectedfs_fclose(&result32, file); // we don't care about the result
+#endif
+			file = NULL;
+		}
+	}
+}
+
+
+void protected_fs_file::init_fields()
+{
+	meta_data_node_number = 0;
+	memset(&file_meta_data, 0, sizeof(meta_data_node_t));
+	memset(&encrypted_part_plain, 0, sizeof(meta_data_encrypted_t));
+
+	memset(&empty_iv, 0, sizeof(sgx_iv_t));
+
+	memset(&root_mht, 0, sizeof(file_mht_node_t));
+	root_mht.type = FILE_MHT_NODE_TYPE;
+	root_mht.physical_node_number = 1;
+	root_mht.mht_node_number = 0;
+	root_mht.new_node = true;
+	root_mht.need_writing = false;
+	
+	offset = 0;
+	file = NULL;
+	end_of_file = false;
+	need_writing = false;
+	read_only = 0;
+	file_status = SGX_FILE_STATUS_NOT_INITIALIZED;
+	last_error = SGX_SUCCESS;
+	real_file_size = 0;	
+	open_mode.raw = 0;
+	use_user_kdk_key = 0;
+	master_key_count = 0;
+
+	recovery_filename[0] = '\0';
+	
+	memset(&mutex, 0, sizeof(sgx_thread_mutex_t));
+
+	// set hash size to fit MAX_PAGES_IN_CACHE
+	cache.rehash(MAX_PAGES_IN_CACHE);
+}
+
+
+#define MAX_MODE_STRING_LEN 5
+bool protected_fs_file::parse_mode(const char* mode)
+{
+	if (mode == NULL) // re-check
+		return false;
+
+	size_t mode_len = strnlen(mode, MAX_MODE_STRING_LEN+1);
+	if (mode_len > MAX_MODE_STRING_LEN)
+		return false;
+
+	for (size_t i = 0 ; i < mode_len ; i++)
+	{
+		switch (mode[i])
+		{
+		case 'r':
+			if (open_mode.write == 1 || open_mode.read == 1 || open_mode.append == 1)
+				return false;
+			open_mode.read = 1;
+			break;
+		case 'w':
+			if (open_mode.write == 1 || open_mode.read == 1 || open_mode.append == 1)
+				return false;
+			open_mode.write = 1;
+			break;
+		case 'a':
+			if (open_mode.write == 1 || open_mode.read == 1 || open_mode.append == 1)
+				return false;
+			open_mode.append = 1;
+			break;
+		case 'b':
+			if (open_mode.binary == 1)
+				return false;
+			open_mode.binary = 1;
+			break;
+		case '+':
+			if (open_mode.update == 1)
+				return false;
+			open_mode.update = 1;
+			break;
+		default:
+			return false;
+		}
+	}
+
+	if (open_mode.write == 0 && open_mode.read == 0 && open_mode.append == 0)
+		return false;
+
+	return true;
+}
+
+
+bool protected_fs_file::file_recovery(const char* filename)
+{
+	sgx_status_t status = SGX_SUCCESS;
+	int32_t result32 = 0;
+	int64_t new_file_size = 0;
+
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_fclose(file);
+#else
+	status = u_sgxprotectedfs_fclose(&result32, file);
+#endif
+	if (status != SGX_SUCCESS || result32 != 0)
+	{
+		last_error = (status != SGX_SUCCESS) ? status : 
+					 (result32 != -1) ? result32 : EINVAL;
+		return false;
+	}
+
+	file = NULL;
+
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_do_file_recovery(filename, recovery_filename, NODE_SIZE);
+#else
+	status = u_sgxprotectedfs_do_file_recovery(&result32, filename, recovery_filename, NODE_SIZE);
+#endif
+
+	if (status != SGX_SUCCESS || result32 != 0)
+	{
+		last_error = (status != SGX_SUCCESS) ? status :
+					 (result32 != -1) ? result32 : EINVAL;
+		return false;
+	}
+
+#ifdef NON_SGX_PROTECTED_FS
+	file = u_sgxprotectedfs_exclusive_file_open(filename, read_only, &new_file_size, &result32);
+#else
+	status = u_sgxprotectedfs_exclusive_file_open(&file, filename, read_only, &new_file_size, &result32);
+#endif
+	if (status != SGX_SUCCESS || file == NULL)
+	{
+		last_error = (status != SGX_SUCCESS) ? status : 
+					 (result32 != 0) ? result32 : EACCES;
+		return false;
+	}
+
+	// recovery only change existing data, it does not shrink or grow the file
+	if (new_file_size != real_file_size)
+	{
+		last_error = SGX_ERROR_UNEXPECTED;
+		return false;
+	}
+
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_fread_node(file, 0, (uint8_t*)&file_meta_data, NODE_SIZE);
+#else
+	status = u_sgxprotectedfs_fread_node(&result32, file, 0, (uint8_t*)&file_meta_data, NODE_SIZE);
+#endif
+	if (status != SGX_SUCCESS || result32 != 0)
+	{
+		last_error = (status != SGX_SUCCESS) ? status : 
+					 (result32 != -1) ? result32 : EIO;
+		return false;
+	}
+
+	return true;
+}
+
+
+bool protected_fs_file::init_existing_file(const char* filename, const char* clean_filename, const sgx_aes_gcm_128bit_key_t* import_key)
+{
+	sgx_status_t status = SGX_SUCCESS;
+	int32_t result32;
+
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_fread_node(file, 0, (uint8_t*)&file_meta_data, NODE_SIZE);
+#else
+	// read meta-data node
+	status = u_sgxprotectedfs_fread_node(&result32, file, 0, (uint8_t*)&file_meta_data, NODE_SIZE);
+#endif
+	if (status != SGX_SUCCESS || result32 != 0)
+	{
+		last_error = (status != SGX_SUCCESS) ? status : 
+					 (result32 != -1) ? result32 : EIO;
+		return false;
+	}
+
+	if (file_meta_data.plain_part.file_id != SGX_FILE_ID)
+	{// such a file exists, but it is not an SGX file
+		last_error = SGX_ERROR_FILE_NOT_SGX_FILE;
+		return false;
+	}
+
+	if (file_meta_data.plain_part.major_version != SGX_FILE_MAJOR_VERSION)
+	{
+		last_error = ENOTSUP;
+		return false;
+	}
+
+	if (file_meta_data.plain_part.update_flag == 1)
+	{// file was in the middle of an update, must do a recovery
+		if (file_recovery(filename) == false)
+		{// override internal error
+			last_error = SGX_ERROR_FILE_RECOVERY_NEEDED;
+			return false;
+		}
+
+		if (file_meta_data.plain_part.update_flag == 1) // recovery failed, flag is still set!
+		{// recovery didn't clear the flag
+			last_error = SGX_ERROR_FILE_RECOVERY_NEEDED;
+			return false;
+		}
+
+		// re-check after recovery
+		if (file_meta_data.plain_part.major_version != SGX_FILE_MAJOR_VERSION)
+		{
+			last_error = ENOTSUP;
+			return false;
+		}
+	}
+
+	if (file_meta_data.plain_part.use_user_kdk_key != use_user_kdk_key)
+	{
+		last_error = EINVAL;
+		return false;
+	}
+
+	if (restore_current_meta_data_key(import_key) == false)
+		return false;
+
+	// decrypt the encrypted part of the meta-data
+	status = sgx_rijndael128GCM_decrypt(&cur_key, 
+										(const uint8_t*)file_meta_data.encrypted_part, sizeof(meta_data_encrypted_blob_t), (uint8_t*)&encrypted_part_plain,
+										empty_iv, SGX_AESGCM_IV_SIZE,
+										NULL, 0,
+										&file_meta_data.plain_part.meta_data_gmac);
+	if (status != SGX_SUCCESS)
+	{
+		last_error = status;
+		return false;
+	}
+
+	if (strncmp(clean_filename, encrypted_part_plain.clean_filename, FILENAME_MAX_LEN) != 0)
+	{
+		last_error = SGX_ERROR_FILE_NAME_MISMATCH;
+		return false;
+	}
+
+/*
+	sgx_mc_uuid_t empty_mc_uuid = {0};
+
+	// check if the file contains an active monotonic counter
+	if (consttime_memequal(&empty_mc_uuid, &encrypted_part_plain.mc_uuid, sizeof(sgx_mc_uuid_t)) == 0)
+	{
+		uint32_t mc_value = 0;
+
+		status = sgx_read_monotonic_counter(&encrypted_part_plain.mc_uuid, &mc_value);
+		if (status != SGX_SUCCESS)
+		{
+			last_error = status;
+			return false;
+		}
+
+		if (encrypted_part_plain.mc_value < mc_value)
+		{
+			last_error = SGX_ERROR_FILE_MONOTONIC_COUNTER_IS_BIGGER;
+			return false;
+		}
+
+		if (encrypted_part_plain.mc_value == mc_value + 1) // can happen if AESM failed - file value stayed one higher
+		{
+			sgx_status_t status = sgx_increment_monotonic_counter(&encrypted_part_plain.mc_uuid, &mc_value);
+			if (status != SGX_SUCCESS)
+			{
+				file_status = SGX_FILE_STATUS_MC_NOT_INCREMENTED;
+				last_error = status;
+				return false;
+			}
+		}
+
+		if (encrypted_part_plain.mc_value != mc_value)
+		{
+			file_status = SGX_FILE_STATUS_CORRUPTED;
+			last_error = SGX_ERROR_UNEXPECTED;
+			return false;
+		}
+	}
+	else
+	{
+		assert(encrypted_part_plain.mc_value == 0);
+		encrypted_part_plain.mc_value = 0; // do this anyway for release...
+	}
+*/
+	if (encrypted_part_plain.size > MD_USER_DATA_SIZE)
+	{
+		// read the root node of the mht
+#ifdef NON_SGX_PROTECTED_FS
+		result32 = u_sgxprotectedfs_fread_node(file, 1, root_mht.encrypted.cipher, NODE_SIZE);
+#else
+		status = u_sgxprotectedfs_fread_node(&result32, file, 1, root_mht.encrypted.cipher, NODE_SIZE);
+#endif
+		if (status != SGX_SUCCESS || result32 != 0)
+		{
+			last_error = (status != SGX_SUCCESS) ? status : 
+						 (result32 != -1) ? result32 : EIO;
+			return false;
+		}
+
+		// this also verifies the root mht gmac against the gmac in the meta-data encrypted part
+		status = sgx_rijndael128GCM_decrypt(&encrypted_part_plain.mht_key, 
+											root_mht.encrypted.cipher, NODE_SIZE, (uint8_t*)&root_mht.plain, 
+											empty_iv, SGX_AESGCM_IV_SIZE, NULL, 0, &encrypted_part_plain.mht_gmac);
+		if (status != SGX_SUCCESS)
+		{
+			last_error = status;
+			return false;
+		}
+
+		root_mht.new_node = false;
+	}
+
+	return true;
+}
+
+
+bool protected_fs_file::init_new_file(const char* clean_filename)
+{
+	file_meta_data.plain_part.file_id = SGX_FILE_ID;
+	file_meta_data.plain_part.major_version = SGX_FILE_MAJOR_VERSION;
+	file_meta_data.plain_part.minor_version = SGX_FILE_MINOR_VERSION;
+
+	file_meta_data.plain_part.use_user_kdk_key = use_user_kdk_key;
+
+	strncpy(encrypted_part_plain.clean_filename, clean_filename, FILENAME_MAX_LEN);
+	
+	need_writing = true;
+
+	return true;
+}
+
+
+protected_fs_file::~protected_fs_file()
+{
+	void* data;
+	
+	while ((data = cache.get_last()) != NULL)
+	{
+		if (((file_data_node_t*)data)->type == FILE_DATA_NODE_TYPE) // type is in the same offset in both node types, need to scrub the plaintext
+		{
+			file_data_node_t* file_data_node = (file_data_node_t*)data;
+			memset_s(&file_data_node->plain, sizeof(data_node_t), 0, sizeof(data_node_t));
+			delete file_data_node;
+		}
+		else
+		{
+			file_mht_node_t* file_mht_node = (file_mht_node_t*)data;
+			memset_s(&file_mht_node->plain, sizeof(mht_node_t), 0, sizeof(mht_node_t));
+			delete file_mht_node;
+		}
+		cache.remove_last();
+	}
+
+	// scrub the last encryption key and the session key
+	memset_s(&cur_key, sizeof(sgx_aes_gcm_128bit_key_t), 0, sizeof(sgx_aes_gcm_128bit_key_t));
+	memset_s(&session_master_key, sizeof(sgx_aes_gcm_128bit_key_t), 0, sizeof(sgx_aes_gcm_128bit_key_t));
+	
+	// scrub first 3KB of user data and the gmac_key
+	memset_s(&encrypted_part_plain, sizeof(meta_data_encrypted_t), 0, sizeof(meta_data_encrypted_t));
+
+	sgx_thread_mutex_destroy(&mutex);
+}
+
+
+bool protected_fs_file::pre_close(sgx_key_128bit_t* key, bool import)
+{
+	int32_t result32 = 0;
+	bool retval = true;
+	sgx_status_t status = SGX_SUCCESS;
+
+	sgx_thread_mutex_lock(&mutex);
+
+	if (import == true)
+	{
+		if (use_user_kdk_key == 1) // import file is only needed for auto-key
+			retval = false;
+		else
+			need_writing = true; // will re-encrypt the neta-data node with local key
+	}
+
+	if (file_status != SGX_FILE_STATUS_OK)
+	{
+		sgx_thread_mutex_unlock(&mutex);
+		clear_error(); // last attempt to fix it
+		sgx_thread_mutex_lock(&mutex);
+	}
+	else // file_status == SGX_FILE_STATUS_OK
+	{
+		internal_flush(/*false,*/ true);
+	}
+
+	if (file_status != SGX_FILE_STATUS_OK)
+		retval = false;
+
+	if (file != NULL)
+	{
+#ifdef NON_SGX_PROTECTED_FS
+		result32 = u_sgxprotectedfs_fclose(file);
+#else
+		status = u_sgxprotectedfs_fclose(&result32, file);
+#endif
+		if (status != SGX_SUCCESS || result32 != 0)
+		{
+			last_error = (status != SGX_SUCCESS) ? status : 
+						 (result32 != -1) ? result32 : SGX_ERROR_FILE_CLOSE_FAILED;
+			retval = false;
+		}
+
+		file = NULL;
+	}
+
+	if (file_status == SGX_FILE_STATUS_OK && 
+		last_error == SGX_SUCCESS) // else...maybe something bad happened and the recovery file will be needed
+		erase_recovery_file();
+
+	if (key != NULL)
+	{
+		if (use_user_kdk_key == 1) // export key is only used for auto-key
+		{
+			retval = false;
+		}
+		else
+		{
+			if (restore_current_meta_data_key(NULL) == true)
+				memcpy(key, cur_key, sizeof(sgx_key_128bit_t));
+			else
+				retval = false;
+		}
+	}
+
+	file_status = SGX_FILE_STATUS_CLOSED;
+
+	sgx_thread_mutex_unlock(&mutex);
+
+	return retval;
+}
+

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_other.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_other.cpp
@@ -1,0 +1,389 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "protected_fs_config.h"
+
+#include "sgx_tprotected_fs.h"
+#include "sgx_tprotected_fs_t.h"
+#include "protected_fs_file.h"
+
+#ifdef NON_SGX_PROTECTED_FS
+#include "non_sgx_protected_fs.h"
+#else
+#include <sgx_utils.h>
+//#include <sgx_trts.h>
+#endif
+
+#include <errno.h>
+
+// this function returns 0 only if the specified file existed and it was actually deleted
+// before we do that, we try to see if the file contained a monotonic counter, and if it did, we delete it from the system
+int32_t protected_fs_file::remove(const char* filename)
+{
+	sgx_status_t status = SGX_SUCCESS;
+	int32_t result32 = 0;
+
+/*
+	void* file = NULL;
+	int64_t real_file_size = 0;
+
+	if (filename == NULL)
+		return 1;
+
+	meta_data_node_t* file_meta_data = NULL;
+	meta_data_encrypted_t* encrypted_part_plain = NULL;
+
+	// if we have a problem in any of the stages, we simply jump to the end and try to remove the file...
+	do {
+		status = u_sgxprotectedfs_check_if_file_exists(&result, filename);
+		if (status != SGX_SUCCESS)
+			break;
+
+		if (result == 0)
+		{
+			errno = EINVAL;
+			return 1; // no such file, or file locked so we can't delete it anyways
+		}
+
+		try {
+			file_meta_data = new meta_data_node_t;
+			encrypted_part_plain = new meta_data_encrypted_t;
+		}
+		catch (std::bad_alloc e) {
+			break;
+		}
+
+		status = u_sgxprotectedfs_exclusive_file_open(&file, filename, 1, &real_file_size, &result32);
+		if (status != SGX_SUCCESS || file == NULL)
+			break;
+
+		if (real_file_size == 0 || real_file_size % NODE_SIZE != 0)
+			break; // empty file or not an SGX protected FS file
+		
+		// might be an SGX protected FS file
+		status = u_sgxprotectedfs_fread_node(&result32, file, 0, (uint8_t*)file_meta_data, NODE_SIZE);
+		if (status != SGX_SUCCESS || result32 != 0)
+			break;
+
+		if (file_meta_data->plain_part.major_version != SGX_FILE_MAJOR_VERSION)
+			break;
+	
+		sgx_aes_gcm_128bit_key_t zero_key_id = {0};
+		sgx_aes_gcm_128bit_key_t key = {0};
+		if (consttime_memequal(&file_meta_data->plain_part.key_id, &zero_key_id, sizeof(sgx_aes_gcm_128bit_key_t)) == 1)
+			break; // shared file - no monotonic counter
+		
+		sgx_key_request_t key_request = {0};
+		key_request.key_name = SGX_KEYSELECT_SEAL;
+		key_request.key_policy = SGX_KEYPOLICY_MRENCLAVE;
+		memcpy(&key_request.key_id, &file_meta_data->plain_part.key_id, sizeof(sgx_key_id_t));
+		
+		status = sgx_get_key(&key_request, &key);
+		if (status != SGX_SUCCESS)
+			break;		
+
+		status = sgx_rijndael128GCM_decrypt(&key, 
+											file_meta_data->encrypted_part, sizeof(meta_data_encrypted_blob_t),
+											(uint8_t*)encrypted_part_plain,
+											file_meta_data->plain_part.meta_data_iv, SGX_AESGCM_IV_SIZE,
+											NULL, 0,
+											&file_meta_data->plain_part.meta_data_gmac);
+		if (status != SGX_SUCCESS)
+			break;
+
+		sgx_mc_uuid_t empty_mc_uuid = {0};
+		if (consttime_memequal(&empty_mc_uuid, &encrypted_part_plain->mc_uuid, sizeof(sgx_mc_uuid_t)) == 0)
+		{
+			status = sgx_destroy_monotonic_counter(&encrypted_part_plain->mc_uuid);
+			if (status != SGX_SUCCESS)
+				break;
+
+			// monotonic counter was deleted, mission accomplished!!
+		}
+	}
+	while (0);
+
+	// cleanup
+	if (file_meta_data != NULL)
+		delete file_meta_data;
+
+	if (encrypted_part_plain != NULL)
+	{
+		// scrub the encrypted part
+		memset_s(encrypted_part_plain, sizeof(meta_data_encrypted_t), 0, sizeof(meta_data_encrypted_t));
+		delete encrypted_part_plain;
+	}
+
+	if (file != NULL) 
+		u_sgxprotectedfs_fclose(&result32, file);
+
+*/
+	
+	// do the actual file removal
+  
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_remove(filename);
+#else
+	status = u_sgxprotectedfs_remove(&result32, filename);
+#endif
+	if (status != SGX_SUCCESS) 
+	{
+		errno = status;
+		return 1;
+	}
+
+	if (result32 != 0)
+	{
+		if (result32 == -1) // no external errno value
+			errno = EPERM;
+		else
+			errno = result32;
+
+		return 1;
+	}
+
+	return 0;
+}
+
+
+int64_t protected_fs_file::tell()
+{
+	int64_t result;
+
+	sgx_thread_mutex_lock(&mutex);
+
+	if (file_status != SGX_FILE_STATUS_OK)
+	{
+		errno = EPERM;
+		last_error = SGX_ERROR_FILE_BAD_STATUS;
+		sgx_thread_mutex_unlock(&mutex);
+		return -1;
+	}
+
+	result = offset;
+
+	sgx_thread_mutex_unlock(&mutex);
+
+	return result;
+}
+
+
+// we don't support sparse files, fseek beyond the current file size will fail
+int protected_fs_file::seek(int64_t new_offset, int origin)
+{
+	sgx_thread_mutex_lock(&mutex);
+
+	if (file_status != SGX_FILE_STATUS_OK)
+	{
+		last_error = SGX_ERROR_FILE_BAD_STATUS;
+		sgx_thread_mutex_unlock(&mutex);
+		return -1;
+	}
+
+	//if (open_mode.binary == 0 && origin != SEEK_SET && new_offset != 0)
+	//{
+	//	last_error = EINVAL;
+	//	sgx_thread_mutex_unlock(&mutex);
+	//	return -1;
+	//}
+
+	int result = -1;
+
+	switch (origin)
+	{
+	case SEEK_SET:
+		if (new_offset >= 0 && new_offset <= encrypted_part_plain.size)
+		{
+			offset = new_offset;
+			result = 0;
+		}
+		break;
+
+	case SEEK_CUR:
+		if ((offset + new_offset) >= 0 && (offset + new_offset) <= encrypted_part_plain.size)
+		{
+			offset += new_offset;
+			result = 0;
+		}
+		break;
+
+	case SEEK_END:
+		if (new_offset <= 0 && new_offset >= (0 - encrypted_part_plain.size))
+		{
+			offset = encrypted_part_plain.size + new_offset;
+			result = 0;
+		}
+		break;
+
+	default: 
+		break;
+	}
+
+	if (result == 0)
+		end_of_file = false;
+	else
+		last_error = EINVAL;
+
+	sgx_thread_mutex_unlock(&mutex);
+
+	return result;
+}
+
+
+uint32_t protected_fs_file::get_error()
+{
+	uint32_t result = SGX_SUCCESS;
+
+	sgx_thread_mutex_lock(&mutex);
+
+	if (last_error != SGX_SUCCESS)
+		result = last_error;
+	else if (file_status != SGX_FILE_STATUS_OK)
+		result = SGX_ERROR_FILE_BAD_STATUS;
+
+	sgx_thread_mutex_unlock(&mutex);
+
+	return result;
+}
+
+
+bool protected_fs_file::get_eof()
+{
+	return end_of_file;
+}
+
+
+void protected_fs_file::clear_error()
+{
+	sgx_thread_mutex_lock(&mutex);
+
+	if (file_status == SGX_FILE_STATUS_NOT_INITIALIZED ||
+		file_status == SGX_FILE_STATUS_CLOSED ||
+		file_status == SGX_FILE_STATUS_CRYPTO_ERROR ||
+		file_status == SGX_FILE_STATUS_CORRUPTED ||
+		file_status == SGX_FILE_STATUS_MEMORY_CORRUPTED) // can't fix these...
+	{
+		sgx_thread_mutex_unlock(&mutex);
+		return;
+	}
+
+	if (file_status == SGX_FILE_STATUS_FLUSH_ERROR)
+	{
+		if (internal_flush(/*false,*/ true) == true)
+			file_status = SGX_FILE_STATUS_OK;
+	}
+
+	if (file_status == SGX_FILE_STATUS_WRITE_TO_DISK_FAILED)
+	{
+		if (write_all_changes_to_disk(true) == true)
+		{
+			need_writing = false;
+			file_status = SGX_FILE_STATUS_OK;
+		}
+	}
+
+/*
+	if (file_status == SGX_FILE_STATUS_WRITE_TO_DISK_FAILED_NEED_MC)
+	{
+		if (write_all_changes_to_disk(true) == true)
+		{
+			need_writing = false;
+			file_status = SGX_FILE_STATUS_MC_NOT_INCREMENTED; // fall through...next 'if' should take care of this one
+		}
+	}
+
+	if ((file_status == SGX_FILE_STATUS_MC_NOT_INCREMENTED) && 
+		(encrypted_part_plain.mc_value <= (UINT_MAX-2)))
+	{
+		uint32_t mc_value;
+		sgx_status_t status = sgx_increment_monotonic_counter(&encrypted_part_plain.mc_uuid, &mc_value);
+		if (status == SGX_SUCCESS)
+		{
+			assert(mc_value == encrypted_part_plain.mc_value);
+			file_status = SGX_FILE_STATUS_OK;
+		}
+		else
+		{
+			last_error = status;
+		}
+	}
+*/
+	
+	if (file_status == SGX_FILE_STATUS_OK)
+	{
+		last_error = SGX_SUCCESS;
+		end_of_file = false;
+	}
+	sgx_thread_mutex_unlock(&mutex);
+}
+
+
+// clears the cache with all the plain data that was in it
+// doesn't clear the meta-data and first node, which are part of the 'main' structure
+int32_t protected_fs_file::clear_cache()
+{
+	sgx_thread_mutex_lock(&mutex);
+
+	if (file_status != SGX_FILE_STATUS_OK)
+	{
+		sgx_thread_mutex_unlock(&mutex);
+		clear_error(); // attempt to fix the file, will also flush it
+		sgx_thread_mutex_lock(&mutex);
+	}
+	else // file_status == SGX_FILE_STATUS_OK
+	{
+		internal_flush(/*false,*/ true);
+	}
+
+	if (file_status != SGX_FILE_STATUS_OK) // clearing the cache might lead to losing un-saved data
+	{
+		sgx_thread_mutex_unlock(&mutex);
+		return 1;
+	}
+
+	while (cache.size() > 0)
+	{
+		void* data = cache.get_last();
+
+		assert(data != NULL);
+		assert(((file_data_node_t*)data)->need_writing == false); // need_writing is in the same offset in both node types
+		// for production - 
+		if (data == NULL || ((file_data_node_t*)data)->need_writing == true)
+		{
+			sgx_thread_mutex_unlock(&mutex);
+			return 1;
+		}
+		
+		cache.remove_last();
+
+		// before deleting the memory, need to scrub the plain secrets
+		if (((file_data_node_t*)data)->type == FILE_DATA_NODE_TYPE) // type is in the same offset in both node types
+		{
+			file_data_node_t* file_data_node = (file_data_node_t*)data;
+			memset_s(&file_data_node->plain, sizeof(data_node_t), 0, sizeof(data_node_t));
+			delete file_data_node;
+		}
+		else
+		{
+			file_mht_node_t* file_mht_node = (file_mht_node_t*)data;
+			memset_s(&file_mht_node->plain, sizeof(mht_node_t), 0, sizeof(mht_node_t));
+			delete file_mht_node;
+		}
+	}
+
+	sgx_thread_mutex_unlock(&mutex);
+
+	return 0;
+}
+

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_read_write.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_read_write.cpp
@@ -1,0 +1,658 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "protected_fs_config.h"
+
+#include "sgx_tprotected_fs_t.h"
+#include "protected_fs_file.h"
+
+#ifdef NON_SGX_PROTECTED_FS
+#include "non_sgx_protected_fs.h"
+#else
+#include <sgx_trts.h>
+#endif
+
+size_t protected_fs_file::write(const void* ptr, size_t size, size_t count)
+{
+	if (ptr == NULL || size == 0 || count == 0)
+		return 0;
+
+	int32_t result32 = sgx_thread_mutex_lock(&mutex);
+	if (result32 != 0)
+	{
+		last_error = result32;
+		file_status = SGX_FILE_STATUS_MEMORY_CORRUPTED;
+		return 0;
+	}
+
+	size_t data_left_to_write = size * count;
+
+	// prevent overlap...
+#if defined(_WIN64) || defined(__x86_64__)
+	if (size > UINT32_MAX || count > UINT32_MAX)
+	{
+		last_error = EINVAL;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+#else
+	if (((uint64_t)((uint64_t)size * (uint64_t)count)) != (uint64_t)data_left_to_write)
+	{
+		last_error = EINVAL;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+#endif
+
+#ifndef NON_SGX_PROTECTED_FS
+	if (sgx_is_outside_enclave(ptr, data_left_to_write))
+	{
+		last_error = SGX_ERROR_INVALID_PARAMETER;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+#endif
+
+	if (file_status != SGX_FILE_STATUS_OK)
+	{
+		last_error = SGX_ERROR_FILE_BAD_STATUS;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+
+	if (open_mode.append == 0 && open_mode.update == 0 && open_mode.write == 0)
+	{
+		last_error = EACCES;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+
+	if (open_mode.append == 1)
+		offset = encrypted_part_plain.size; // add at the end of the file
+
+	const unsigned char* data_to_write = (const unsigned char*)ptr;
+
+	// the first block of user data is written in the meta-data encrypted part
+	if (offset < MD_USER_DATA_SIZE)
+	{
+		size_t empty_place_left_in_md = MD_USER_DATA_SIZE - (size_t)offset; // offset is smaller than MD_USER_DATA_SIZE
+		if (data_left_to_write <= empty_place_left_in_md)
+		{
+			memcpy(&encrypted_part_plain.data[offset], data_to_write, data_left_to_write);
+			offset += data_left_to_write;
+			data_to_write += data_left_to_write; // not needed, to prevent future errors
+			data_left_to_write = 0;
+		}
+		else
+		{
+			memcpy(&encrypted_part_plain.data[offset], data_to_write, empty_place_left_in_md);
+			offset += empty_place_left_in_md;
+			data_to_write += empty_place_left_in_md;
+			data_left_to_write -= empty_place_left_in_md;
+		}
+		
+		if (offset > encrypted_part_plain.size)
+			encrypted_part_plain.size = offset; // file grew, update the new file size
+
+		need_writing = true;
+	}
+
+	while (data_left_to_write > 0)
+	{
+		file_data_node_t* file_data_node = NULL;
+		file_data_node = get_data_node(); // return the data node of the current offset, will read it from disk or create new one if needed (and also the mht node if needed)
+		if (file_data_node == NULL)
+			break;
+
+		size_t offset_in_node = (size_t)((offset - MD_USER_DATA_SIZE) % NODE_SIZE);
+		size_t empty_place_left_in_node = NODE_SIZE - offset_in_node;
+		
+		if (data_left_to_write <= empty_place_left_in_node)
+		{ // this will be the last write
+			memcpy(&file_data_node->plain.data[offset_in_node], data_to_write, data_left_to_write);
+			offset += data_left_to_write;
+			data_to_write += data_left_to_write; // not needed, to prevent future errors
+			data_left_to_write = 0;
+		}
+		else
+		{
+			memcpy(&file_data_node->plain.data[offset_in_node], data_to_write, empty_place_left_in_node);
+			offset += empty_place_left_in_node;
+			data_to_write += empty_place_left_in_node;
+			data_left_to_write -= empty_place_left_in_node;
+
+		}
+
+		if (offset > encrypted_part_plain.size)
+			encrypted_part_plain.size = offset; // file grew, update the new file size
+
+		if (file_data_node->need_writing == false)
+		{
+			file_data_node->need_writing = true;
+			file_mht_node_t* file_mht_node = file_data_node->parent;
+			while (file_mht_node->mht_node_number != 0) // set all the mht parent nodes as 'need writing'
+			{
+				file_mht_node->need_writing = true;
+				file_mht_node = file_mht_node->parent;
+			}
+			root_mht.need_writing = true;
+			need_writing = true;
+		}
+	}
+
+	sgx_thread_mutex_unlock(&mutex);
+
+	size_t ret_count = ((size * count) - data_left_to_write) / size;
+	return ret_count;
+}
+
+
+size_t protected_fs_file::read(void* ptr, size_t size, size_t count)
+{
+	if (ptr == NULL || size == 0 || count == 0)
+		return 0;
+
+	int32_t result32 = sgx_thread_mutex_lock(&mutex);
+	if (result32 != 0)
+	{
+		last_error = result32;
+		file_status = SGX_FILE_STATUS_MEMORY_CORRUPTED;
+		return 0;
+	}
+
+	size_t data_left_to_read = size * count;
+
+	// prevent overlap...
+#if defined(_WIN64) || defined(__x86_64__)
+	if (size > UINT32_MAX || count > UINT32_MAX)
+	{
+		last_error = EINVAL;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+#else
+	if (((uint64_t)((uint64_t)size * (uint64_t)count)) != (uint64_t)data_left_to_read)
+	{
+		last_error = EINVAL;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+#endif
+
+
+#ifndef NON_SGX_PROTECTED_FS
+	if (sgx_is_outside_enclave(ptr, data_left_to_read))
+	{
+		last_error = EINVAL;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+#endif
+
+	if (file_status != SGX_FILE_STATUS_OK)
+	{
+		last_error = SGX_ERROR_FILE_BAD_STATUS;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+
+	if (open_mode.read == 0 && open_mode.update == 0)
+	{
+		last_error = EACCES;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+
+	if (end_of_file == true)
+	{// not an error
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+
+	// this check is not really needed, can go on with the code and it will do nothing until the end, but it's more 'right' to check it here
+	if (offset == encrypted_part_plain.size)
+	{
+		end_of_file = true;
+		sgx_thread_mutex_unlock(&mutex);
+		return 0;
+	}
+
+	if (((uint64_t)data_left_to_read) > (uint64_t)(encrypted_part_plain.size - offset)) // the request is bigger than what's left in the file
+	{
+		data_left_to_read = (size_t)(encrypted_part_plain.size - offset);
+	}
+	size_t data_attempted_to_read = data_left_to_read; // used at the end to return how much we actually read
+
+	unsigned char* out_buffer = (unsigned char*)ptr;
+
+	// the first block of user data is read from the meta-data encrypted part
+	if (offset < MD_USER_DATA_SIZE)
+	{
+		size_t data_left_in_md = MD_USER_DATA_SIZE - (size_t)offset; // offset is smaller than MD_USER_DATA_SIZE
+		if (data_left_to_read <= data_left_in_md)
+		{
+			memcpy(out_buffer, &encrypted_part_plain.data[offset], data_left_to_read);
+			offset += data_left_to_read;
+			out_buffer += data_left_to_read; // not needed, to prevent future errors
+			data_left_to_read = 0;
+		}
+		else
+		{
+			memcpy(out_buffer, &encrypted_part_plain.data[offset], data_left_in_md);
+			offset += data_left_in_md;
+			out_buffer += data_left_in_md;
+			data_left_to_read -= data_left_in_md;
+		}
+	}
+
+	while (data_left_to_read > 0)
+	{
+		file_data_node_t* file_data_node = NULL;
+		file_data_node = get_data_node(); // return the data node of the current offset, will read it from disk if needed (and also the mht node if needed)
+		if (file_data_node == NULL)
+			break;
+
+		size_t offset_in_node = (offset - MD_USER_DATA_SIZE) % NODE_SIZE;
+		size_t data_left_in_node = NODE_SIZE - offset_in_node;
+		
+		if (data_left_to_read <= data_left_in_node)
+		{
+			memcpy(out_buffer, &file_data_node->plain.data[offset_in_node], data_left_to_read);
+			offset += data_left_to_read;
+			out_buffer += data_left_to_read; // not needed, to prevent future errors
+			data_left_to_read = 0;
+		}
+		else
+		{
+			memcpy(out_buffer, &file_data_node->plain.data[offset_in_node], data_left_in_node);
+			offset += data_left_in_node;
+			out_buffer += data_left_in_node;
+			data_left_to_read -= data_left_in_node;
+
+		}
+	}
+
+	sgx_thread_mutex_unlock(&mutex);
+
+	if (data_left_to_read == 0 &&
+		data_attempted_to_read != (size * count)) // user wanted to read more and we had to shrink the request
+	{
+		assert(offset == encrypted_part_plain.size);
+		end_of_file = true;
+	}
+
+	size_t ret_count = (data_attempted_to_read - data_left_to_read) / size;
+	return ret_count;
+}
+
+
+// this is a very 'specific' function, tied to the architecture of the file layout, returning the node numbers according to the offset in the file 
+void get_node_numbers(uint64_t offset, uint64_t* mht_node_number, uint64_t* data_node_number, 
+					 uint64_t* physical_mht_node_number, uint64_t* physical_data_node_number)
+{
+	// node 0 - meta data node
+	// node 1 - mht
+	// nodes 2-97 - data (ATTACHED_DATA_NODES_COUNT == 96)
+	// node 98 - mht
+	// node 99-195 - data
+	// etc.
+	uint64_t _mht_node_number;
+	uint64_t _data_node_number;
+	uint64_t _physical_mht_node_number;
+	uint64_t _physical_data_node_number;
+
+	assert(offset >= MD_USER_DATA_SIZE);
+
+	_data_node_number = (offset - MD_USER_DATA_SIZE) / NODE_SIZE;
+	_mht_node_number = _data_node_number / ATTACHED_DATA_NODES_COUNT;
+	_physical_data_node_number = _data_node_number
+								+ 1 // meta data node
+								+ 1 // mht root
+								+ _mht_node_number; // number of mht nodes in the middle (the root mht mht_node_number is 0)
+	_physical_mht_node_number = _physical_data_node_number
+								- _data_node_number % ATTACHED_DATA_NODES_COUNT // now we are at the first data node attached to this mht node
+								- 1; // and now at the mht node itself!
+
+	if (mht_node_number != NULL) *mht_node_number = _mht_node_number;
+	if (data_node_number != NULL) *data_node_number = _data_node_number;
+	if (physical_mht_node_number != NULL) *physical_mht_node_number = _physical_mht_node_number;
+	if (physical_data_node_number != NULL) *physical_data_node_number = _physical_data_node_number;
+}
+
+
+file_data_node_t* protected_fs_file::get_data_node()
+{
+	file_data_node_t* file_data_node = NULL;
+
+	if (offset < MD_USER_DATA_SIZE)
+	{
+		last_error = SGX_ERROR_UNEXPECTED;
+		return NULL;
+	}
+
+	if ((offset - MD_USER_DATA_SIZE) % NODE_SIZE == 0 && 
+		offset == encrypted_part_plain.size)
+	{// new node
+		file_data_node = append_data_node();
+	}
+	else
+	{// existing node
+		file_data_node = read_data_node();
+	}
+
+	// bump all the parents mht to reside before the data node in the cache
+	if (file_data_node != NULL)
+	{
+		file_mht_node_t* file_mht_node = file_data_node->parent;
+		while (file_mht_node->mht_node_number != 0)
+		{
+			cache.get(file_mht_node->physical_node_number); // bump the mht node to the head of the lru
+			file_mht_node = file_mht_node->parent;
+		}
+	}
+
+	// even if we didn't get the required data_node, we might have read other nodes in the process
+	while (cache.size() > MAX_PAGES_IN_CACHE)
+	{
+		void* data = cache.get_last();
+		assert(data != NULL);
+		// for production - 
+		if (data == NULL)
+		{
+			last_error = SGX_ERROR_UNEXPECTED;
+			return NULL;
+		}
+		if (((file_data_node_t*)data)->need_writing == false) // need_writing is in the same offset in both node types
+		{
+			cache.remove_last();
+
+			// before deleting the memory, need to scrub the plain secrets
+			if (((file_data_node_t*)data)->type == FILE_DATA_NODE_TYPE) // type is in the same offset in both node types
+			{
+				file_data_node_t* file_data_node1 = (file_data_node_t*)data;
+				memset_s(&file_data_node1->plain, sizeof(data_node_t), 0, sizeof(data_node_t));
+				delete file_data_node1;
+			}
+			else
+			{
+				file_mht_node_t* file_mht_node = (file_mht_node_t*)data;
+				memset_s(&file_mht_node->plain, sizeof(mht_node_t), 0, sizeof(mht_node_t));
+				delete file_mht_node;
+			}
+		}
+		else
+		{
+			if (internal_flush(/*false,*/ false) == false) // error, can't flush cache, file status changed to error
+			{
+				assert(file_status != SGX_FILE_STATUS_OK);
+				if (file_status == SGX_FILE_STATUS_OK)
+					file_status = SGX_FILE_STATUS_FLUSH_ERROR; // for release set this anyway
+				return NULL; // even if we got the data_node!
+			}
+		}
+	}
+	
+	return file_data_node;
+}
+
+
+file_data_node_t* protected_fs_file::append_data_node()
+{
+	file_mht_node_t* file_mht_node = get_mht_node();
+	if (file_mht_node == NULL) // some error happened
+		return NULL;
+
+	file_data_node_t* new_file_data_node = NULL;
+
+	try {
+		new_file_data_node = new file_data_node_t;
+	}
+	catch (std::bad_alloc& e) {
+		(void)e; // remove warning
+		last_error = ENOMEM;
+		return NULL;
+	}
+	memset(new_file_data_node, 0, sizeof(file_data_node_t));
+
+	new_file_data_node->type = FILE_DATA_NODE_TYPE;
+	new_file_data_node->new_node = true;
+	new_file_data_node->parent = file_mht_node;
+	get_node_numbers(offset, NULL, &new_file_data_node->data_node_number, NULL, &new_file_data_node->physical_node_number);
+
+	if (cache.add(new_file_data_node->physical_node_number, new_file_data_node) == false)
+	{
+		delete new_file_data_node;
+		last_error = ENOMEM;
+		return NULL;
+	}
+
+	return new_file_data_node;
+}
+
+
+file_data_node_t* protected_fs_file::read_data_node()
+{
+	uint64_t data_node_number;
+	uint64_t physical_node_number;
+	file_mht_node_t* file_mht_node;
+	int32_t result32;
+	sgx_status_t status = SGX_SUCCESS;
+
+	get_node_numbers(offset, NULL, &data_node_number, NULL, &physical_node_number);
+
+	file_data_node_t* file_data_node = (file_data_node_t*)cache.get(physical_node_number);
+	if (file_data_node != NULL)
+		return file_data_node;
+	
+	// need to read the data node from the disk
+
+	file_mht_node = get_mht_node();
+	if (file_mht_node == NULL) // some error happened
+		return NULL;
+
+	try {
+		file_data_node = new file_data_node_t;
+	}
+	catch (std::bad_alloc& e) {
+		(void)e; // remove warning
+		last_error = ENOMEM;
+		return NULL;
+	}
+	memset(file_data_node, 0, sizeof(file_data_node_t));
+	file_data_node->type = FILE_DATA_NODE_TYPE;
+	file_data_node->data_node_number = data_node_number;
+	file_data_node->physical_node_number = physical_node_number;
+	file_data_node->parent = file_mht_node;
+		
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_fread_node(file, file_data_node->physical_node_number, file_data_node->encrypted.cipher, NODE_SIZE);
+#else
+	status = u_sgxprotectedfs_fread_node(&result32, file, file_data_node->physical_node_number, file_data_node->encrypted.cipher, NODE_SIZE);
+#endif
+	if (status != SGX_SUCCESS || result32 != 0)
+	{
+		delete file_data_node;
+		last_error = (status != SGX_SUCCESS) ? status : 
+					 (result32 != -1) ? result32 : EIO;
+		return NULL;
+	}
+
+	gcm_crypto_data_t* gcm_crypto_data = &file_data_node->parent->plain.data_nodes_crypto[file_data_node->data_node_number % ATTACHED_DATA_NODES_COUNT];
+
+	// this function decrypt the data _and_ checks the integrity of the data against the gmac
+	status = sgx_rijndael128GCM_decrypt(&gcm_crypto_data->key, file_data_node->encrypted.cipher, NODE_SIZE, file_data_node->plain.data, empty_iv, SGX_AESGCM_IV_SIZE, NULL, 0, &gcm_crypto_data->gmac);
+	if (status != SGX_SUCCESS)
+	{
+		delete file_data_node;
+		last_error = status;
+		if (status == SGX_ERROR_MAC_MISMATCH)
+		{
+			file_status = SGX_FILE_STATUS_CORRUPTED;
+		}
+		return NULL;
+	}
+		
+	if (cache.add(file_data_node->physical_node_number, file_data_node) == false)
+	{
+		memset_s(&file_data_node->plain, sizeof(data_node_t), 0, sizeof(data_node_t)); // scrub the plaintext data
+		delete file_data_node;
+		last_error = ENOMEM;
+		return NULL;
+	}
+
+	return file_data_node;
+}
+
+
+file_mht_node_t* protected_fs_file::get_mht_node()
+{
+	file_mht_node_t* file_mht_node;
+	uint64_t mht_node_number;
+	uint64_t physical_mht_node_number;
+
+	if (offset < MD_USER_DATA_SIZE)
+	{
+		last_error = SGX_ERROR_UNEXPECTED;
+		return NULL;
+	}
+
+	get_node_numbers(offset, &mht_node_number, NULL, &physical_mht_node_number, NULL);
+
+	if (mht_node_number == 0)
+		return &root_mht;
+
+	// file is constructed from 128*4KB = 512KB per MHT node.
+	if ((offset - MD_USER_DATA_SIZE) % (ATTACHED_DATA_NODES_COUNT * NODE_SIZE) == 0 && 
+		 offset == encrypted_part_plain.size)
+	{
+		file_mht_node = append_mht_node(mht_node_number);
+	}
+	else
+	{
+		file_mht_node = read_mht_node(mht_node_number);
+	}
+
+	return file_mht_node;
+}
+
+
+file_mht_node_t* protected_fs_file::append_mht_node(uint64_t mht_node_number)
+{
+	file_mht_node_t* parent_file_mht_node = read_mht_node((mht_node_number - 1) / CHILD_MHT_NODES_COUNT);
+	if (parent_file_mht_node == NULL) // some error happened
+		return NULL;
+
+	uint64_t physical_node_number = 1 + // meta data node
+										mht_node_number * (1 + ATTACHED_DATA_NODES_COUNT); // the '1' is for the mht node preceding every 96 data nodes
+
+	file_mht_node_t* new_file_mht_node = NULL;
+	try {
+		new_file_mht_node = new file_mht_node_t;
+	}
+	catch (std::bad_alloc& e) {
+		(void)e; // remove warning
+		last_error = ENOMEM;
+		return NULL;
+	}
+	memset(new_file_mht_node, 0, sizeof(file_mht_node_t));
+
+	new_file_mht_node->type = FILE_MHT_NODE_TYPE;
+	new_file_mht_node->new_node = true;
+	new_file_mht_node->parent = parent_file_mht_node;
+	new_file_mht_node->mht_node_number = mht_node_number;
+	new_file_mht_node->physical_node_number = physical_node_number;
+
+	if (cache.add(new_file_mht_node->physical_node_number, new_file_mht_node) == false)
+	{
+		delete new_file_mht_node;
+		last_error = ENOMEM;
+		return NULL;
+	}
+	
+	return new_file_mht_node;
+}
+
+
+file_mht_node_t* protected_fs_file::read_mht_node(uint64_t mht_node_number)
+{
+	int32_t result32;
+	sgx_status_t status = SGX_SUCCESS;
+
+	if (mht_node_number == 0)
+		return &root_mht;
+
+	uint64_t physical_node_number = 1 + // meta data node
+										mht_node_number * (1 + ATTACHED_DATA_NODES_COUNT); // the '1' is for the mht node preceding every 96 data nodes
+
+	file_mht_node_t* file_mht_node = (file_mht_node_t*)cache.find(physical_node_number);
+	if (file_mht_node != NULL)
+		return file_mht_node;
+
+	file_mht_node_t* parent_file_mht_node = read_mht_node((mht_node_number - 1) / CHILD_MHT_NODES_COUNT);
+	if (parent_file_mht_node == NULL) // some error happened
+		return NULL;
+
+	try {
+		file_mht_node = new file_mht_node_t;
+	}
+	catch (std::bad_alloc& e) {
+		(void)e; // remove warning
+		last_error = ENOMEM;
+		return NULL;
+	}
+	memset(file_mht_node, 0, sizeof(file_mht_node_t));
+	file_mht_node->type = FILE_MHT_NODE_TYPE;
+	file_mht_node->mht_node_number = mht_node_number;
+	file_mht_node->physical_node_number = physical_node_number;
+	file_mht_node->parent = parent_file_mht_node;
+		
+#ifdef NON_SGX_PROTECTED_FS
+	result32 = u_sgxprotectedfs_fread_node(file, file_mht_node->physical_node_number, file_mht_node->encrypted.cipher, NODE_SIZE);
+#else
+	status = u_sgxprotectedfs_fread_node(&result32, file, file_mht_node->physical_node_number, file_mht_node->encrypted.cipher, NODE_SIZE);
+#endif
+	if (status != SGX_SUCCESS || result32 != 0)
+	{
+		delete file_mht_node;
+		last_error = (status != SGX_SUCCESS) ? status : 
+					 (result32 != -1) ? result32 : EIO;
+		return NULL;
+	}
+	
+	gcm_crypto_data_t* gcm_crypto_data = &file_mht_node->parent->plain.mht_nodes_crypto[(file_mht_node->mht_node_number - 1) % CHILD_MHT_NODES_COUNT];
+
+	// this function decrypt the data _and_ checks the integrity of the data against the gmac
+	status = sgx_rijndael128GCM_decrypt(&gcm_crypto_data->key, file_mht_node->encrypted.cipher, NODE_SIZE, (uint8_t*)&file_mht_node->plain, empty_iv, SGX_AESGCM_IV_SIZE, NULL, 0, &gcm_crypto_data->gmac);
+	if (status != SGX_SUCCESS)
+	{
+		delete file_mht_node;
+		last_error = status;
+		if (status == SGX_ERROR_MAC_MISMATCH)
+		{
+			file_status = SGX_FILE_STATUS_CORRUPTED;
+		}
+		return NULL;
+	}
+
+	if (cache.add(file_mht_node->physical_node_number, file_mht_node) == false)
+	{
+		memset_s(&file_mht_node->plain, sizeof(mht_node_t), 0, sizeof(mht_node_t));
+		delete file_mht_node;
+		last_error = ENOMEM;
+		return NULL;
+	}
+
+	return file_mht_node;
+}
+

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_version.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/file_version.cpp
@@ -12,8 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod common_setup;
-pub mod kms_test;
-pub mod protected_fs_test;
-pub mod tdfs_test;
-pub mod tms_test;
+#include "se_version.h"
+
+#define __CONCAT(x, y) x/**/y
+
+#define SGX_TPROTECTEDFS_VERSION_STR  __CONCAT("SGX_TPROTECTEDFS_VERSION_", STRFILEVER)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+__attribute__((visibility("default")))
+char sgx_tprotectedfs_version[] = SGX_TPROTECTEDFS_VERSION_STR;
+#ifdef __cplusplus
+}
+#endif

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/lru_cache.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/lru_cache.cpp
@@ -1,0 +1,258 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lru_cache.h"
+
+
+
+lru_cache::lru_cache()
+{
+	m_it = list.begin();
+}
+
+
+lru_cache::~lru_cache()
+{
+	list_node_t* list_node;
+	map_node_t* map_node;
+	
+	while (list.size() > 0)
+	{
+		list_node = list.front();
+		map_node = map[list_node->key];
+		
+		map.erase(list_node->key);
+		delete map_node;
+
+		list.pop_front();
+		delete list_node;
+	}
+
+	assert(list.empty() == true);
+	assert(map.empty() == true);
+}
+
+
+void lru_cache::rehash(uint32_t size_)
+{
+	map.rehash(size_);
+}
+
+
+bool lru_cache::add(uint64_t key, void* data)
+{
+	map_node_t* map_node = NULL;
+	list_node_t* list_node = NULL;
+	
+	try {
+		map_node = new map_node_t();
+		list_node = new list_node_t();
+	}
+	catch (std::bad_alloc& e) {
+		(void)e; // remove warning
+		return false;
+	}
+	
+	list_node->key = key;
+	list.push_front(list_node);
+
+	map_iterator map_it = map.find(key);
+	assert(map_it == map.end());
+	if (map_it != map.end())
+	{
+		// this indicates some fatal problem, perhaps race issue caused by bad locks...
+		map_node_t* tmp_map_node = map_it->second;
+		if (tmp_map_node != NULL)
+			delete tmp_map_node;
+		map.erase(map_it);
+	}
+
+	map_node->data = data;
+	map_node->list_it = list.begin();
+	
+	map[key] = map_node;
+	
+	return true;
+}
+
+
+void* lru_cache::find(uint64_t key)
+{
+	map_iterator map_it = map.find(key);
+	if (map_it == map.end())
+		return NULL;
+
+	map_node_t* map_node = map_it->second;
+	return map_node->data;
+}
+
+
+void* lru_cache::get(uint64_t key)
+{
+	map_iterator map_it = map.find(key);
+	if (map_it == map.end())
+		return NULL;
+
+	map_node_t* map_node = map_it->second;
+
+	list_node_t* list_node = *(map_node->list_it);
+	assert(list_node != NULL);
+	if (list_node == NULL) // this should never happen, but just in case, code is here to fix it
+	{
+		try {
+			list_node = new list_node_t();
+			list_node->key = map_it->first;
+		}
+		catch (std::bad_alloc& e) {
+			(void)e; // remove warning
+			return NULL;
+		}
+	}
+	
+	list.erase(map_node->list_it);
+	list.push_front(list_node);
+
+	map_node->list_it = list.begin();
+
+	return map_node->data;
+}
+
+
+uint32_t lru_cache::size()
+{
+	assert(list.size() == map.size());
+	return (uint32_t)list.size();
+}
+
+
+void* lru_cache::get_first()
+{
+	if (list.size() == 0)
+		return NULL;
+
+	m_it = list.begin();
+	if (m_it == list.end())
+		return NULL;
+
+	list_node_t* list_node = (*m_it);
+	assert(list_node != NULL);
+	if (list_node == NULL)
+		return NULL;
+
+	map_iterator map_it = map.find(list_node->key);
+	assert(map_it != map.end());
+	if (map_it == map.end())
+		return NULL;
+
+	map_node_t* map_node = map_it->second;
+	assert(map_node != NULL);
+	if (map_node == NULL)
+		return NULL;
+
+	return map_node->data;
+}
+
+void* lru_cache::get_next()
+{
+	if (list.size() == 0)
+		return NULL;
+
+	++m_it;
+
+	if (m_it == list.end())
+		return NULL;
+
+	list_node_t* list_node = (*m_it);
+	assert(list_node != NULL);
+	if (list_node == NULL)
+		return NULL;
+
+	map_iterator map_it = map.find(list_node->key);
+	assert(map_it != map.end());
+	if (map_it == map.end())
+		return NULL;
+
+	map_node_t* map_node = map_it->second;
+	assert(map_node != NULL);
+	if (map_node == NULL)
+		return NULL;
+
+	return map_node->data;
+}
+
+
+void* lru_cache::get_last()
+{
+	if (list.size() == 0)
+		return NULL;
+
+	list_iterator it = list.end(); // pointer to the object past-the-end
+	assert(it != list.begin());
+	if (it == list.begin()) // the list is empty
+		return NULL;
+	
+	--it; // now it points to the last object
+	list_node_t* list_node = (*it);
+	assert(list_node != NULL);
+	if (list_node == NULL)
+		return NULL;
+
+	map_iterator map_it = map.find(list_node->key);
+	assert(map_it != map.end());
+	if (map_it == map.end())
+		return NULL;
+
+	map_node_t* map_node = map_it->second;
+	assert(map_node != NULL);
+	if (map_node == NULL)
+		return NULL;
+
+	return map_node->data;
+}
+
+
+void lru_cache::remove_last()
+{
+	uint64_t key;
+
+	list_iterator it = list.end(); // pointer to the object past-the-end
+	if (it == list.begin()) // the list is empty
+		return;
+
+	--it; // now it points to the last object
+
+	list_node_t* list_node = (*it);
+	list.erase(it);
+	
+	assert(list_node != NULL);
+	if (list_node == NULL) // unclear how this can happen...
+		return;
+
+	key = list_node->key;
+	delete list_node;
+
+	map_iterator map_it = map.find(key);
+	assert(map_it != map.end());
+	if (map_it == map.end())
+		return;
+
+	map_node_t* map_node = map_it->second;
+	assert(map_node != NULL);
+	if (map_node == NULL)
+		return;
+
+	map.erase(key);
+	delete map_node;
+}
+

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/lru_cache.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/lru_cache.h
@@ -1,0 +1,82 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifndef _LRU_CACHE_H_
+#define _LRU_CACHE_H_
+
+#include <assert.h>
+
+#include <list>
+
+/* STL map is implemented as a tree, hence all operations are O(logN)
+   STL unordered_map is implemented as hash, hence all operations are O(1)
+   http://stackoverflow.com/questions/2196995/is-there-any-advantage-of-using-map-over-unordered-map-in-case-of-trivial-keys
+   http://stackoverflow.com/questions/3902644/choosing-between-stdmap-and-stdunordered-map
+   */
+
+#include <unordered_map>
+
+/* this hasher code was needed since strict ansi don't allow 'long long' type
+ * adding -U__STRICT_ANSI__ to the compilation flags solved the issue
+ * leaving this code here for future reference
+namespace stlpmtx_std
+{
+template<> struct hash<uint64_t> {
+  size_t operator()(uint64_t x) const { return (size_t)x; }
+  };
+}
+*/
+
+typedef struct _list_node
+{
+	uint64_t key;
+} list_node_t;
+
+typedef struct _map_node
+{
+	void* data;
+	std::list<list_node_t*>::iterator list_it;
+} map_node_t;
+
+typedef std::unordered_map<uint64_t, map_node_t*>::iterator map_iterator;
+typedef std::list<list_node_t*>::iterator list_iterator;
+
+class lru_cache
+{
+private:
+	std::list<list_node_t*> list;
+	std::unordered_map<uint64_t, map_node_t*> map;
+
+	list_iterator m_it; // for get_first and get_next sequence
+
+public:	
+	lru_cache();
+	~lru_cache();
+
+	void rehash(uint32_t size_);
+
+	bool add(uint64_t key, void* p);
+	void* get(uint64_t key);
+	void* find(uint64_t key); // only returns the object, do not bump it to the head
+	uint32_t size();
+
+	void* get_first();
+	void* get_next();
+	void* get_last();
+	void remove_last();
+};
+
+#endif // _LRU_CACHE_H_

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/non_sgx_protected_fs.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/non_sgx_protected_fs.cpp
@@ -1,0 +1,309 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "non_sgx_protected_fs.h"
+#include "openssl/cmac.h"
+#include "openssl/err.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+
+/* Message Authentication - Rijndael 128 CMAC
+* Parameters:
+*   Return: sgx_status_t  - SGX_SUCCESS or failure as defined sgx_error.h
+*   Inputs: sgx_cmac_128bit_key_t *p_key - Pointer to key used in encryption/decryption operation
+*           uint8_t *p_src - Pointer to input stream to be MACed
+*           uint32_t src_len - Length of input stream to be MACed
+*   Output: sgx_cmac_gcm_128bit_tag_t *p_mac - Pointer to resultant MAC */
+sgx_status_t sgx_rijndael128_cmac_msg(const sgx_cmac_128bit_key_t *p_key, const uint8_t *p_src,
+                                      uint32_t src_len, sgx_cmac_128bit_tag_t *p_mac)
+{
+	void* pState = NULL;
+
+	if ((p_key == NULL) || (p_src == NULL) || (p_mac == NULL))  {
+		return SGX_ERROR_INVALID_PARAMETER;
+	}
+
+	size_t mactlen;
+	sgx_status_t ret = SGX_ERROR_UNEXPECTED;
+
+	do {
+		//create a new ctx of CMAC
+		//
+		pState = CMAC_CTX_new();
+		if (pState == NULL) {
+			ret = SGX_ERROR_OUT_OF_MEMORY;
+			break;
+		}
+
+		// init CMAC ctx with the corresponding size, key and AES alg.
+		//
+		if (!CMAC_Init((CMAC_CTX*)pState, (const void *)p_key, SGX_CMAC_KEY_SIZE, EVP_aes_128_cbc(), NULL)) {
+			break;
+		}
+
+		// perform CMAC hash on p_src
+		//
+		if (!CMAC_Update((CMAC_CTX *)pState, p_src, src_len)) {
+			break;
+		}
+
+		// finalize CMAC hashing
+		//
+		if (!CMAC_Final((CMAC_CTX*)pState, (unsigned char*)p_mac, &mactlen)) {
+			break;
+		}
+
+		//validate mac size
+		//
+		if (mactlen != SGX_CMAC_MAC_SIZE) {
+			break;
+		}
+
+		ret = SGX_SUCCESS;
+	} while (0);
+
+	// we're done, clear and free CMAC ctx
+	//
+	if (pState) {
+		CMAC_CTX_free((CMAC_CTX*)pState);
+	}
+	return ret;
+}
+
+
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+sgx_status_t read_rand(uint8_t *buf, size_t size)
+{
+    int fd = open("/dev/urandom", O_RDONLY);
+    if (fd == -1) {
+        return SGX_ERROR_UNEXPECTED; 
+    }
+    read(fd, buf, size);
+    close(fd);
+    return SGX_SUCCESS;
+}
+
+int memset_s(void *s, size_t smax, int c, size_t n)
+{
+    int err = 0;
+
+    if (s == NULL) {
+        err = EINVAL;
+        goto out;
+    }
+
+    if (n > smax) {
+        err = EOVERFLOW;
+        n = smax;
+    }
+
+    /* Calling through a volatile pointer should never be optimised away. */
+    memset(s, c, n);
+
+    out:
+    if (err == 0)
+        return 0;
+    else {
+        errno = err;
+        /* XXX call runtime-constraint handler */
+        return err;
+    }
+}
+
+
+sgx_status_t sgx_rijndael128GCM_encrypt(const sgx_aes_gcm_128bit_key_t *p_key, const uint8_t *p_src, uint32_t src_len,
+                                        uint8_t *p_dst, const uint8_t *p_iv, uint32_t iv_len, const uint8_t *p_aad, uint32_t aad_len,
+                                        sgx_aes_gcm_128bit_tag_t *p_out_mac)
+{
+    if ((src_len >= INT_MAX) || (aad_len >= INT_MAX) || (p_key == NULL) || ((src_len > 0) && (p_dst == NULL)) || ((src_len > 0) && (p_src == NULL))
+        || (p_out_mac == NULL) || (iv_len != SGX_AESGCM_IV_SIZE) || ((aad_len > 0) && (p_aad == NULL))
+        || (p_iv == NULL) || ((p_src == NULL) && (p_aad == NULL)))
+    {
+        return SGX_ERROR_INVALID_PARAMETER;
+    }
+    sgx_status_t ret = SGX_ERROR_UNEXPECTED;
+    int len = 0;
+    EVP_CIPHER_CTX * pState = NULL;
+
+
+    do {
+        // Create and init ctx
+        //
+        if (!(pState = EVP_CIPHER_CTX_new()))
+        {
+            ret = SGX_ERROR_OUT_OF_MEMORY;
+            break;
+        }
+
+        // Initialise encrypt, key and IV
+        //
+        if (1 != EVP_EncryptInit_ex(pState, EVP_aes_128_gcm(), NULL, (unsigned char*)p_key, p_iv))
+        {
+            break;
+        }
+
+        // Provide AAD data if exist
+        //
+        if (aad_len > 0)
+        {
+            if (1 != EVP_EncryptUpdate(pState, NULL, &len, p_aad, aad_len))
+            {
+                break;
+            }
+        }
+
+        // Provide the message to be encrypted, and obtain the encrypted output.
+        //
+        if(src_len > 0)
+        {
+            if (1 != EVP_EncryptUpdate(pState, p_dst, &len, p_src, src_len))
+            {
+                break;
+            }
+        }
+        // Finalise the encryption
+        //
+        if (1 != EVP_EncryptFinal_ex(pState, p_dst + len, &len))
+        {
+            break;
+        }
+
+        // Get tag
+        //
+        if (1 != EVP_CIPHER_CTX_ctrl(pState, EVP_CTRL_GCM_GET_TAG, SGX_AESGCM_MAC_SIZE, p_out_mac))
+        {
+            break;
+        }
+        ret = SGX_SUCCESS;
+    } while (0);
+
+
+    // Clean up and return
+    //
+    if (pState) {
+            EVP_CIPHER_CTX_free(pState);
+    }
+    return ret;
+}
+
+sgx_status_t sgx_rijndael128GCM_decrypt(const sgx_aes_gcm_128bit_key_t *p_key, const uint8_t *p_src,
+                                        uint32_t src_len, uint8_t *p_dst, const uint8_t *p_iv, uint32_t iv_len,
+                                        const uint8_t *p_aad, uint32_t aad_len, const sgx_aes_gcm_128bit_tag_t *p_in_mac)
+{
+    uint8_t l_tag[SGX_AESGCM_MAC_SIZE] = {0};
+
+    if ((src_len >= INT_MAX) || (aad_len >= INT_MAX) || (p_key == NULL) || ((src_len > 0) && (p_dst == NULL)) || ((src_len > 0) && (p_src == NULL))
+        || (p_in_mac == NULL) || (iv_len != SGX_AESGCM_IV_SIZE) || ((aad_len > 0) && (p_aad == NULL))
+        || (p_iv == NULL) || ((p_src == NULL) && (p_aad == NULL)))
+    {
+        return SGX_ERROR_INVALID_PARAMETER;
+    }
+    int len = 0;
+    sgx_status_t ret = SGX_ERROR_UNEXPECTED;
+    EVP_CIPHER_CTX * pState = NULL;
+
+    // Autenthication Tag returned by Decrypt to be compared with Tag created during seal
+    //
+    memset_s(&l_tag, SGX_AESGCM_MAC_SIZE, 0, SGX_AESGCM_MAC_SIZE);
+    memcpy(l_tag, p_in_mac, SGX_AESGCM_MAC_SIZE);
+
+    do {
+        // Create and initialise the context
+        //
+        if (!(pState = EVP_CIPHER_CTX_new()))
+        {
+            ret = SGX_ERROR_OUT_OF_MEMORY;
+            break;
+        }
+
+        // Initialise decrypt, key and IV
+        //
+        if (!EVP_DecryptInit_ex(pState, EVP_aes_128_gcm(), NULL, (unsigned char*)p_key, p_iv))
+        {
+            break;
+        }
+
+        // Provide AAD data if exist
+        //
+        if (aad_len > 0) 
+        {
+            if (!EVP_DecryptUpdate(pState, NULL, &len, p_aad, aad_len)) 
+            {
+                break;
+            }
+        }
+
+        // Decrypt message, obtain the plaintext output
+        //
+        if(src_len > 0)
+        {       
+            if (!EVP_DecryptUpdate(pState, p_dst, &len, p_src, src_len))
+            {
+                break;
+            }
+        }
+
+        // Update expected tag value
+        //
+        if (!EVP_CIPHER_CTX_ctrl(pState, EVP_CTRL_GCM_SET_TAG, SGX_AESGCM_MAC_SIZE, l_tag))
+        {
+            break;
+        }
+
+        // Finalise the decryption. A positive return value indicates success,
+        // anything else is a failure - the plaintext is not trustworthy.
+        //
+        if (EVP_DecryptFinal_ex(pState, p_dst + len, &len) <= 0)
+        {
+            break;
+        }
+        ret = SGX_SUCCESS;
+    } while (0);
+
+    // Clean up and return
+    //
+    if (pState != NULL)
+    {
+        EVP_CIPHER_CTX_free(pState);
+    }
+    memset_s(&l_tag, SGX_AESGCM_MAC_SIZE, 0, SGX_AESGCM_MAC_SIZE);
+    return ret;
+}
+
+int
+consttime_memequal(const void *b1, const void *b2, size_t len)
+{
+	const unsigned char *c1 = (const unsigned char*)b1, *c2 = (const unsigned char*)b2;
+	unsigned int res = 0;
+
+	while (len--)
+		res |= *c1++ ^ *c2++;
+
+	/*
+	 * Map 0 to 1 and [1, 256) to 0 using only constant-time
+	 * arithmetic.
+	 *
+	 * This is not simply `!res' because although many CPUs support
+	 * branchless conditional moves and many compilers will take
+	 * advantage of them, certain compilers generate branches on
+	 * certain CPUs for `!res'.
+	 */
+	return (1 & ((res - 1) >> 8));
+}

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/protected_fs_file.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/protected_fs_file.h
@@ -1,0 +1,233 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifndef _PROTECTED_FS_H_
+#define _PROTECTED_FS_H_
+
+#include "protected_fs_config.h"
+
+#include "protected_fs_nodes.h"
+#include "lru_cache.h"
+#ifdef NON_SGX_PROTECTED_FS
+#include "non_sgx_protected_fs.h"
+#else
+#include "sgx_error.h"
+#include "sgx_tcrypto.h"
+#include "errno.h"
+#include <sgx_thread.h>
+#endif
+#include "sgx_tprotected_fs.h"
+
+typedef enum
+{
+	SGX_FILE_STATUS_OK = 0,
+	SGX_FILE_STATUS_NOT_INITIALIZED,
+	SGX_FILE_STATUS_FLUSH_ERROR,
+	SGX_FILE_STATUS_WRITE_TO_DISK_FAILED,
+	SGX_FILE_STATUS_CRYPTO_ERROR,
+	SGX_FILE_STATUS_CORRUPTED,
+	SGX_FILE_STATUS_MEMORY_CORRUPTED,
+	//SGX_FILE_STATUS_WRITE_TO_DISK_FAILED_NEED_MC,
+	//SGX_FILE_STATUS_MC_NOT_INCREMENTED,
+	SGX_FILE_STATUS_CLOSED,
+} protected_fs_status_e;
+
+#define MAX_PAGES_IN_CACHE 48
+
+//COMPILE_TIME_ASSERT(filename_length, FILENAME_MAX_LEN == FILENAME_MAX);
+COMPILE_TIME_ASSERT(filename_length, FILENAME_MAX_LEN <= FILENAME_MAX);
+
+#ifdef NON_SGX_PROTECTED_FS
+#else
+typedef void FILE;
+#endif
+
+typedef union
+{
+	struct
+	{
+		uint8_t read   :1;
+		uint8_t write  :1;
+		uint8_t append :1;
+		uint8_t binary: 1;
+		uint8_t update: 1;
+	};
+	uint8_t raw;
+} open_mode_t;
+
+
+#define FILE_MHT_NODE_TYPE  1
+#define FILE_DATA_NODE_TYPE 2
+
+#define PATHNAME_MAX_LEN      (512)
+#define FULLNAME_MAX_LEN      (PATHNAME_MAX_LEN+FILENAME_MAX_LEN)
+#define RECOVERY_FILE_MAX_LEN (FULLNAME_MAX_LEN+10)
+
+#pragma pack(push, 1)
+
+/*
+the following 2 structures are almost identical, i do not merge them (union or c++ inheritance from parent class) for 2 reasons:
+1. when the code was written, they were much more different, during time the differences were almost gone, but "if it's working don't fix it", so i leave it this way
+2. the code is more readable this way, it is clear when we deal with each type
+*/
+typedef struct _file_mht_node
+{
+	/* these are exactly the same as file_data_node_t below, any change should apply to both (both are saved in the cache as void*) */
+	uint8_t type;
+	uint64_t mht_node_number;
+	struct _file_mht_node* parent;
+	bool need_writing;
+	bool new_node;
+	union {
+		struct {
+			uint64_t physical_node_number;
+			encrypted_node_t encrypted; // the actual data from the disk
+		};
+		recovery_node_t recovery_node;
+	};
+	/* from here the structures are different */
+	mht_node_t plain; // decrypted data
+} file_mht_node_t;
+
+
+typedef struct _file_data_node
+{
+	/* these are exactly the same as file_mht_node_t above, any change should apply to both (both are saved in the cache as void*) */
+	uint8_t type;
+	uint64_t data_node_number;
+	file_mht_node_t* parent;
+	bool need_writing;
+	bool new_node;
+	union {
+		struct {
+			uint64_t physical_node_number;
+			encrypted_node_t encrypted; // the actual data from the disk
+		};
+		recovery_node_t recovery_node;
+	};
+	/* from here the structures are different */
+	data_node_t plain; // decrypted data
+} file_data_node_t;
+
+
+class protected_fs_file
+{
+private:
+	union {
+		struct {
+			uint64_t meta_data_node_number; // for recovery purpose, so it is easy to write this node
+			meta_data_node_t file_meta_data; // actual data from disk's meta data node
+		};
+		recovery_node_t meta_data_recovery_node;
+	};
+
+	meta_data_encrypted_t encrypted_part_plain; // encrypted part of meta data node, decrypted
+	
+	file_mht_node_t root_mht; // the root of the mht is always needed (for files bigger than 3KB)
+
+	FILE* file; // OS's FILE pointer
+	
+	open_mode_t open_mode;
+	uint8_t read_only;
+	int64_t offset; // current file position (user's view)
+	bool end_of_file; // flag
+
+	int64_t real_file_size;
+	
+	bool need_writing; // flag
+	uint32_t last_error; // last operation error
+	protected_fs_status_e file_status;
+	
+#ifdef NON_SGX_PROTECTED_FS
+	pthread_mutex_t mutex;
+#else
+	sgx_thread_mutex_t mutex;
+#endif
+
+	uint8_t use_user_kdk_key;
+#ifdef NON_SGX_PROTECTED_FS
+	aead_128bit_key_t user_kdk_key; // recieved from user, used instead of the seal key
+	aead_128bit_key_t cur_key;
+	aead_128bit_key_t session_master_key;
+#else
+	sgx_aes_gcm_128bit_key_t user_kdk_key; // recieved from user, used instead of the seal key
+	sgx_aes_gcm_128bit_key_t cur_key;
+	sgx_aes_gcm_128bit_key_t session_master_key;
+#endif
+	uint32_t master_key_count;
+	
+	char recovery_filename[RECOVERY_FILE_MAX_LEN]; // might include full path to the file
+
+	lru_cache cache;
+
+	// these don't change after init...
+	sgx_iv_t empty_iv;
+
+#ifdef NON_SGX_PROTECTED_FS
+#else
+	sgx_report_t report;
+#endif
+
+	void init_fields();
+	bool cleanup_filename(const char* src, char* dest);
+	bool parse_mode(const char* mode);
+	bool file_recovery(const char* filename);
+	bool init_existing_file(const char* filename, const char* clean_filename, const sgx_aes_gcm_128bit_key_t* import_key);
+	bool init_new_file(const char* clean_filename);
+	
+	bool generate_secure_blob(sgx_aes_gcm_128bit_key_t* key, const char* label, uint64_t physical_node_number, sgx_aes_gcm_128bit_tag_t* output);
+	bool generate_secure_blob_from_user_kdk(bool restore);
+	bool init_session_master_key();
+	bool derive_random_node_key(uint64_t physical_node_number);
+	bool generate_random_meta_data_key();
+	bool restore_current_meta_data_key(const sgx_aes_gcm_128bit_key_t* import_key);
+	
+	
+	file_data_node_t* get_data_node();
+	file_data_node_t* read_data_node();
+	file_data_node_t* append_data_node();
+	file_mht_node_t* get_mht_node();
+	file_mht_node_t* read_mht_node(uint64_t mht_node_number);
+	file_mht_node_t* append_mht_node(uint64_t mht_node_number);
+	bool write_recovery_file();
+	bool set_update_flag(bool flush_to_disk);
+	void clear_update_flag();
+	bool update_all_data_and_mht_nodes();
+	bool update_meta_data_node();
+	bool write_all_changes_to_disk(bool flush_to_disk);
+	void erase_recovery_file();
+	bool internal_flush(/*bool mc,*/ bool flush_to_disk);
+
+public:
+	protected_fs_file(const char* filename, const char* mode, const sgx_aes_gcm_128bit_key_t* import_key, const sgx_aes_gcm_128bit_key_t* kdk_key);
+	~protected_fs_file();
+
+	size_t write(const void* ptr, size_t size, size_t count);
+	size_t read(void* ptr, size_t size, size_t count);
+	int64_t tell();
+	int seek(int64_t new_offset, int origin);
+	bool get_eof();
+	uint32_t get_error();
+	void clear_error();
+	int32_t clear_cache();
+	bool flush(/*bool mc*/);
+	bool pre_close(sgx_key_128bit_t* key, bool import);
+	static int32_t remove(const char* filename);
+};
+
+#pragma pack(pop)
+
+#endif // _PROTECTED_FS_H_

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/protected_fs_nodes.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/protected_fs_nodes.h
@@ -1,0 +1,142 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifndef _PROTECTED_FS_NODES_H_
+#define _PROTECTED_FS_NODES_H_
+
+#include <stdint.h>
+#include "protected_fs_config.h"
+
+#ifdef NON_SGX_PROTECTED_FS
+#include "non_sgx_protected_fs.h"
+#else
+#include <sgx_report.h>
+#include <sgx_tcrypto.h>
+#include <sgx_tae_service.h>
+#endif
+
+#pragma pack(push, 1)
+
+#define NODE_SIZE 4096
+// the rest of the 'defines' are relative to node size, so we can decrease node size in tests and have deeper tree
+
+// compile time checks
+#define COMPILE_TIME_ASSERT(compile_time_assert_name,compile_time_assert_condition) \
+    typedef unsigned char compile_time_assert_name[(compile_time_assert_condition) ? 1 : -1]
+
+typedef uint8_t sgx_iv_t[SGX_AESGCM_IV_SIZE];
+
+#define SGX_FILE_ID            0x5347585F46494C45 // SGX_FILE
+#define SGX_FILE_MAJOR_VERSION 0x01
+#define SGX_FILE_MINOR_VERSION 0x00
+
+typedef struct _meta_data_plain
+{
+	uint64_t         file_id;
+	uint8_t          major_version;
+	uint8_t          minor_version;
+
+	sgx_key_id_t     meta_data_key_id;
+	sgx_cpu_svn_t    cpu_svn;
+	sgx_isv_svn_t    isv_svn;
+	uint8_t          use_user_kdk_key;
+	sgx_attributes_t attribute_mask;
+
+	sgx_aes_gcm_128bit_tag_t meta_data_gmac;
+	
+	uint8_t          update_flag;
+} meta_data_plain_t;
+
+// these are all defined as relative to node size, so we can decrease node size in tests and have deeper tree
+#define FILENAME_MAX_LEN  260
+#define MD_USER_DATA_SIZE (NODE_SIZE*3/4)  // 3072
+COMPILE_TIME_ASSERT(md_user_data_size, MD_USER_DATA_SIZE == 3072);
+
+typedef struct _meta_data_encrypted
+{
+	char          clean_filename[FILENAME_MAX_LEN];
+	int64_t       size;
+	
+	sgx_mc_uuid_t mc_uuid; // not used
+	uint32_t      mc_value; // not used
+
+	sgx_aes_gcm_128bit_key_t mht_key;
+	sgx_aes_gcm_128bit_tag_t mht_gmac;
+
+	uint8_t       data[MD_USER_DATA_SIZE];
+} meta_data_encrypted_t;
+
+typedef uint8_t meta_data_encrypted_blob_t[sizeof(meta_data_encrypted_t)];
+
+#define META_DATA_NODE_SIZE NODE_SIZE
+typedef uint8_t meta_data_padding_t[META_DATA_NODE_SIZE - (sizeof(meta_data_plain_t) + sizeof(meta_data_encrypted_blob_t))];
+
+typedef struct _meta_data_node
+{
+	meta_data_plain_t          plain_part;
+	meta_data_encrypted_blob_t encrypted_part;
+	meta_data_padding_t        padding;
+} meta_data_node_t;
+
+COMPILE_TIME_ASSERT(sizeof_meta_data_node_t, sizeof(meta_data_node_t) == 4096);
+
+
+typedef struct _data_node_crypto
+{
+	sgx_aes_gcm_128bit_key_t key;
+	sgx_aes_gcm_128bit_tag_t gmac;
+} gcm_crypto_data_t;
+
+// for NODE_SIZE == 4096, we have 96 attached data nodes and 32 mht child nodes
+// for NODE_SIZE == 2048, we have 48 attached data nodes and 16 mht child nodes
+// for NODE_SIZE == 1024, we have 24 attached data nodes and 8 mht child nodes
+#define ATTACHED_DATA_NODES_COUNT ((NODE_SIZE/sizeof(gcm_crypto_data_t))*3/4) // 3/4 of the node size is dedicated to data nodes
+COMPILE_TIME_ASSERT(attached_data_nodes_count, ATTACHED_DATA_NODES_COUNT == 96);
+#define CHILD_MHT_NODES_COUNT ((NODE_SIZE/sizeof(gcm_crypto_data_t))*1/4) // 1/4 of the node size is dedicated to child mht nodes
+COMPILE_TIME_ASSERT(child_mht_nodes_count, CHILD_MHT_NODES_COUNT == 32);
+
+typedef struct _mht_node
+{
+	gcm_crypto_data_t data_nodes_crypto[ATTACHED_DATA_NODES_COUNT];
+	gcm_crypto_data_t mht_nodes_crypto[CHILD_MHT_NODES_COUNT];
+} mht_node_t;
+
+COMPILE_TIME_ASSERT(sizeof_mht_node_t, sizeof(mht_node_t) == 4096);
+
+typedef struct _data_node
+{
+	uint8_t data[NODE_SIZE];
+} data_node_t;
+
+COMPILE_TIME_ASSERT(sizeof_data_node_t, sizeof(data_node_t) == 4096);
+
+typedef struct _encrypted_node
+{
+	uint8_t cipher[NODE_SIZE];
+} encrypted_node_t;
+
+COMPILE_TIME_ASSERT(sizeof_encrypted_node_t, sizeof(encrypted_node_t) == 4096);
+
+typedef struct _recovery_node
+{
+	uint64_t physical_node_number;
+	uint8_t node_data[NODE_SIZE];
+} recovery_node_t;
+
+#pragma pack(pop)
+
+#endif // _PROTECTED_FS_NODES_H_
+

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/se_version.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/se_version.h
@@ -11,9 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#define STRFILEVER    "2.6.100.51363"
+#define COPYRIGHT      "Copyright (C) 2019 Intel Corporation"
 
-pub mod common_setup;
-pub mod kms_test;
-pub mod protected_fs_test;
-pub mod tdfs_test;
-pub mod tms_test;
+#define UAE_SERVICE_VERSION       "1.2.100.0"
+#define URTS_VERSION              "1.1.101.0"
+#define ENCLAVE_COMMON_VERSION    "1.0.104.0"

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/sgx_tprotected_fs.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/sgx_tprotected_fs.cpp
@@ -1,0 +1,237 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "sgx_tprotected_fs.h"
+#include "sgx_tprotected_fs_t.h"
+#include "protected_fs_file.h"
+
+#include <errno.h>
+
+
+static SGX_FILE* sgx_fopen_internal(const char* filename, const char* mode, const sgx_key_128bit_t *auto_key, const sgx_key_128bit_t *kdk_key)
+{
+	protected_fs_file* file = NULL;
+
+	if (filename == NULL || mode == NULL)
+	{
+		errno = EINVAL;
+		return NULL;
+	}
+
+	try {
+		file = new protected_fs_file(filename, mode, auto_key, kdk_key);
+	}
+	catch (std::bad_alloc& e) {
+		(void)e; // remove warning
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	if (file->get_error() != SGX_FILE_STATUS_OK)
+	{
+		errno = file->get_error();
+		delete file;
+		file = NULL;
+	}
+
+	return (SGX_FILE*)file;
+}
+
+
+SGX_FILE* sgx_fopen_auto_key(const char* filename, const char* mode)
+{
+	return sgx_fopen_internal(filename, mode, NULL, NULL);
+}
+
+
+SGX_FILE* sgx_fopen(const char* filename, const char* mode, const sgx_key_128bit_t *key)
+{
+	return sgx_fopen_internal(filename, mode, NULL, key);
+}
+
+
+size_t sgx_fwrite(const void* ptr, size_t size, size_t count, SGX_FILE* stream)
+{
+	if (ptr == NULL || stream == NULL || size == 0 || count == 0)
+		return 0;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return file->write(ptr, size, count);
+}
+
+
+size_t sgx_fread(void* ptr, size_t size, size_t count, SGX_FILE* stream)
+{
+	if (ptr == NULL || stream == NULL || size == 0 || count == 0)
+		return 0;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return file->read(ptr, size, count);
+}
+
+
+int64_t sgx_ftell(SGX_FILE* stream)
+{
+	if (stream == NULL)
+		return -1;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return file->tell();
+}
+
+
+int32_t sgx_fseek(SGX_FILE* stream, int64_t offset, int origin)
+{
+	if (stream == NULL)
+		return -1;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return file->seek(offset, origin);
+}
+
+
+int32_t sgx_fflush(SGX_FILE* stream)
+{
+	if (stream == NULL)
+		return EOPNOTSUPP; // TBD - currently we don't support NULL as fflush input parameter
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return file->flush(/*false*/) == true ? 0 : EOF;
+}
+
+
+/* sgx_fflush_and_increment_mc
+ *  Purpose: force actual write of all the cached data to the disk (see c++ fflush documentation for more details).
+ *           in addition, in the first time this function is called, it adds a monotonic counter to the file
+ *           in subsequent calls, the monotonic counter is incremented by one every time this function is called
+ *           the monotonic counter is a limited resource, please read the SGX documentation for more details
+ *
+ *  Parameters:
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *
+ *  Return value:
+ *     int32_t  - result, 0 on success, 1 in case of an error - check sgx_ferror for error code
+ *
+int32_t sgx_fflush_and_increment_mc(SGX_FILE* stream)
+{
+	if (stream == NULL)
+		return 1;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return file->flush(true) == true ? 0 : 1;
+}
+*/
+
+
+int32_t sgx_ferror(SGX_FILE* stream)
+{
+	if (stream == NULL)
+		return -1;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return file->get_error();
+}
+
+
+int32_t sgx_feof(SGX_FILE* stream)
+{
+	if (stream == NULL)
+		return -1;
+	
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return ((file->get_eof() == true) ? 1 : 0);
+}
+
+
+void sgx_clearerr(SGX_FILE* stream)
+{
+	if (stream == NULL)
+		return;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	file->clear_error();
+}
+
+
+static int32_t sgx_fclose_internal(SGX_FILE* stream, sgx_key_128bit_t *key, bool import)
+{
+	int32_t retval = 0;
+
+	if (stream == NULL)
+		return EOF;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	if (file->pre_close(key, import) == false)
+		retval = 1;
+
+	delete file;
+
+	return retval;
+}
+
+
+int32_t sgx_fclose(SGX_FILE* stream)
+{
+	return sgx_fclose_internal(stream, NULL, false);
+}
+
+
+int32_t sgx_remove(const char* filename)
+{
+	return protected_fs_file::remove(filename);
+}
+
+
+int32_t sgx_fexport_auto_key(const char* filename, sgx_key_128bit_t *key)
+{
+	SGX_FILE* stream = sgx_fopen_internal(filename, "r", NULL, NULL);
+	if (stream == NULL)
+		return 1;
+
+	return sgx_fclose_internal(stream, key, false);
+}
+
+
+int32_t sgx_fimport_auto_key(const char* filename, const sgx_key_128bit_t *key)
+{
+	SGX_FILE* stream = sgx_fopen_internal(filename, "r+", key, NULL);
+	if (stream == NULL)
+		return 1;
+
+	return sgx_fclose_internal(stream, NULL, true);
+}
+
+
+int32_t sgx_fclear_cache(SGX_FILE* stream)
+{
+	if (stream == NULL)
+		return 1;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return file->clear_cache();
+}
+
+
+

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/sgx_tprotected_fs_t.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/sgx_tprotected_fs_t.h
@@ -1,0 +1,72 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SGX_TPROTECTED_FS_T_H__
+#define SGX_TPROTECTED_FS_T_H__
+
+#include "protected_fs_config.h"
+
+#include <stdint.h>
+#include <wchar.h>
+#include <stddef.h>
+
+#ifdef NON_SGX_PROTECTED_FS
+#include "non_sgx_protected_fs.h"
+#define SGX_CDECL
+FILE* u_sgxprotectedfs_exclusive_file_open(const char* filename, uint8_t read_only, int64_t* file_size, int32_t* error_code);
+uint8_t u_sgxprotectedfs_check_if_file_exists(const char* filename);
+int32_t u_sgxprotectedfs_fread_node(FILE* f, uint64_t node_number, uint8_t* buffer, uint32_t node_size);
+int32_t u_sgxprotectedfs_fwrite_node(FILE* f, uint64_t node_number, uint8_t* buffer, uint32_t node_size);
+int32_t u_sgxprotectedfs_fclose(FILE* f);
+uint8_t u_sgxprotectedfs_fflush(FILE* f);
+int32_t u_sgxprotectedfs_remove(const char* filename);
+FILE* u_sgxprotectedfs_recovery_file_open(const char* filename);
+uint8_t u_sgxprotectedfs_fwrite_recovery_node(FILE* f, uint8_t* data, uint32_t data_length);
+int32_t u_sgxprotectedfs_do_file_recovery(const char* filename, const char* recovery_filename, uint32_t node_size);
+#else
+#include "sgx_edger8r.h" /* for sgx_ocall etc. */
+
+#include <stdlib.h> /* for size_t */
+
+#define SGX_CAST(type, item) ((type)(item))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+sgx_status_t SGX_CDECL u_sgxprotectedfs_exclusive_file_open(void** retval, const char* filename, uint8_t read_only, int64_t* file_size, int32_t* error_code);
+sgx_status_t SGX_CDECL u_sgxprotectedfs_check_if_file_exists(uint8_t* retval, const char* filename);
+sgx_status_t SGX_CDECL u_sgxprotectedfs_fread_node(int32_t* retval, void* f, uint64_t node_number, uint8_t* buffer, uint32_t node_size);
+sgx_status_t SGX_CDECL u_sgxprotectedfs_fwrite_node(int32_t* retval, void* f, uint64_t node_number, uint8_t* buffer, uint32_t node_size);
+sgx_status_t SGX_CDECL u_sgxprotectedfs_fclose(int32_t* retval, void* f);
+sgx_status_t SGX_CDECL u_sgxprotectedfs_fflush(uint8_t* retval, void* f);
+sgx_status_t SGX_CDECL u_sgxprotectedfs_remove(int32_t* retval, const char* filename);
+sgx_status_t SGX_CDECL u_sgxprotectedfs_recovery_file_open(void** retval, const char* filename);
+sgx_status_t SGX_CDECL u_sgxprotectedfs_fwrite_recovery_node(uint8_t* retval, void* f, uint8_t* data, uint32_t data_length);
+sgx_status_t SGX_CDECL u_sgxprotectedfs_do_file_recovery(int32_t* retval, const char* filename, const char* recovery_filename, uint32_t node_size);
+sgx_status_t SGX_CDECL create_session_ocall(sgx_status_t* retval, uint32_t* sid, uint8_t* dh_msg1, uint32_t dh_msg1_size, uint32_t timeout);
+sgx_status_t SGX_CDECL exchange_report_ocall(sgx_status_t* retval, uint32_t sid, uint8_t* dh_msg2, uint32_t dh_msg2_size, uint8_t* dh_msg3, uint32_t dh_msg3_size, uint32_t timeout);
+sgx_status_t SGX_CDECL close_session_ocall(sgx_status_t* retval, uint32_t sid, uint32_t timeout);
+sgx_status_t SGX_CDECL invoke_service_ocall(sgx_status_t* retval, uint8_t* pse_message_req, uint32_t pse_message_req_size, uint8_t* pse_message_resp, uint32_t pse_message_resp_size, uint32_t timeout);
+sgx_status_t SGX_CDECL sgx_oc_cpuidex(int cpuinfo[4], int leaf, int subleaf);
+sgx_status_t SGX_CDECL sgx_thread_wait_untrusted_event_ocall(int* retval, const void* self);
+sgx_status_t SGX_CDECL sgx_thread_set_untrusted_event_ocall(int* retval, const void* waiter);
+sgx_status_t SGX_CDECL sgx_thread_setwait_untrusted_events_ocall(int* retval, const void* waiter, const void* self);
+sgx_status_t SGX_CDECL sgx_thread_set_multiple_untrusted_events_ocall(int* retval, const void** waiters, size_t total);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif
+#endif

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/tprotected_fs.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/tprotected_fs.h
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod common_setup;
-pub mod kms_test;
-pub mod protected_fs_test;
-pub mod tdfs_test;
-pub mod tms_test;
+#ifndef _TPROTECTED_FS_H_
+#define _TPROTECTED_FS_H_
+
+// this file should only contain following definition
+#define _RECOVERY_HOOK_(_x) (0)
+
+// this file should remain empty in release environment
+// validation environment will provide a different version of this file
+
+#endif	// _TPROTECTED_FS_H_

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_uprotected_fs/sgx_uprotected_fs.cpp
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_uprotected_fs/sgx_uprotected_fs.cpp
@@ -1,0 +1,526 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "protected_fs_config.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <malloc.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#ifdef NON_SGX_PROTECTED_FS
+#include <stdint.h>
+#else
+#include "sgx_tprotected_fs_u.h"
+#include <uprotected_fs.h>
+#endif
+
+
+#ifdef DEBUG
+#define DEBUG_PRINT(fmt, args...) fprintf(stderr, "[sgx_uprotected_fs.h:%d] " fmt, __LINE__, ##args)
+#else
+#define DEBUG_PRINT(...)
+#endif
+
+
+#ifdef NON_SGX_PROTECTED_FS
+FILE* u_sgxprotectedfs_exclusive_file_open(const char* filename, uint8_t read_only, int64_t* file_size, int32_t* error_code)
+#else
+void* u_sgxprotectedfs_exclusive_file_open(const char* filename, uint8_t read_only, int64_t* file_size, int32_t* error_code)
+#endif
+{
+	FILE* f = NULL;
+	int result = 0;
+	int fd = -1;
+	mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+	struct stat stat_st;
+	
+	memset(&stat_st, 0, sizeof(struct stat));
+
+	if (filename == NULL || strnlen(filename, 1) == 0)
+	{
+		DEBUG_PRINT("filename is NULL or empty\n");
+		*error_code = EINVAL;
+		return NULL;
+	}
+
+	// open the file with OS API so we can 'lock' the file and get exclusive access to it
+	fd = open(filename,	O_CREAT | (read_only ? O_RDONLY : O_RDWR) | O_LARGEFILE, mode); // create the file if it doesn't exists, read-only/read-write
+	if (fd == -1)
+	{
+		DEBUG_PRINT("open returned %d, errno %d\n", result, errno);
+		*error_code = errno;
+		return NULL;
+	}
+
+	// this lock is advisory only and programs with high priviliges can ignore it
+	// it is set to help the user avoid mistakes, but it won't prevent intensional DOS attack from priviliged user
+	result = flock(fd, (read_only ? LOCK_SH : LOCK_EX) | LOCK_NB); // NB - non blocking
+	if (result != 0)
+	{
+		DEBUG_PRINT("flock returned %d, errno %d\n", result, errno);
+		*error_code = errno;
+		result = close(fd);
+		assert(result == 0);
+		return NULL;
+	}
+
+	result = fstat(fd, &stat_st);
+	if (result != 0)
+	{
+		DEBUG_PRINT("fstat returned %d, errno %d\n", result, errno);
+		*error_code = errno;
+		flock(fd, LOCK_UN);
+		result = close(fd);
+		assert(result == 0);
+		return NULL;
+	}
+	
+	// convert the file handle to standard 'C' API file pointer
+	f = fdopen(fd, read_only ? "rb" : "r+b");
+	if (f == NULL)
+	{
+		DEBUG_PRINT("fdopen returned NULL\n");
+		*error_code = errno;
+		flock(fd, LOCK_UN);
+		result = close(fd);
+		assert(result == 0);
+		return NULL;
+	}
+
+	if (file_size != NULL)
+		*file_size = stat_st.st_size;
+
+	return f;
+}
+
+
+uint8_t u_sgxprotectedfs_check_if_file_exists(const char* filename)
+{
+	struct stat stat_st;
+	
+	memset(&stat_st, 0, sizeof(struct stat));
+
+	if (filename == NULL || strnlen(filename, 1) == 0)
+	{
+		DEBUG_PRINT("filename is NULL or empty\n");
+		return 1;
+	}
+	
+	return (stat(filename, &stat_st) == 0); 
+}
+
+
+#ifdef NON_SGX_PROTECTED_FS
+int32_t u_sgxprotectedfs_fread_node(FILE* f, uint64_t node_number, uint8_t* buffer, uint32_t node_size)
+#else
+int32_t u_sgxprotectedfs_fread_node(void* f, uint64_t node_number, uint8_t* buffer, uint32_t node_size)
+#endif
+{
+	FILE* file = (FILE*)f;
+	uint64_t offset = node_number * node_size;
+	int result = 0;
+	size_t size = 0;
+
+	if (file == NULL)
+	{
+		DEBUG_PRINT("file is NULL\n");
+		return -1;
+	}
+
+	if ((result = fseeko(file, offset, SEEK_SET)) != 0)
+	{
+		DEBUG_PRINT("fseeko returned %d\n", result);
+		if (errno != 0)
+		{
+			int err = errno;
+			return err;
+		}
+		else
+			return -1;
+	}
+
+	if ((size = fread(buffer, node_size, 1, file)) != 1)
+	{
+		int err = ferror(file);
+		if (err != 0)
+		{
+			DEBUG_PRINT("fread returned %ld [!= 1], ferror: %d\n", size, err);
+			return err;
+		}
+		else if (errno != 0)
+		{
+			err = errno;
+			DEBUG_PRINT("fread returned %ld [!= 1], errno: %d\n", size, err);
+			return err;
+		}
+		else
+		{
+			DEBUG_PRINT("fread returned %ld [!= 1], no error code\n", size);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+
+#ifdef NON_SGX_PROTECTED_FS
+int32_t u_sgxprotectedfs_fwrite_node(FILE* f, uint64_t node_number, uint8_t* buffer, uint32_t node_size)
+#else
+int32_t u_sgxprotectedfs_fwrite_node(void* f, uint64_t node_number, uint8_t* buffer, uint32_t node_size)
+#endif
+{
+	FILE* file = (FILE*)f;
+	uint64_t offset = node_number * node_size;
+	int result = 0;
+	size_t size = 0;
+
+	if (file == NULL)
+	{
+		DEBUG_PRINT("file is NULL\n");
+		return -1;
+	}
+
+	if ((result = fseeko(file, offset, SEEK_SET)) != 0)
+	{
+		DEBUG_PRINT("fseeko returned %d\n", result);
+		if (errno != 0)
+		{
+			int err = errno;
+			return err;
+		}
+		else
+			return -1;
+	}
+
+	if ((size = fwrite(buffer, node_size, 1, file)) != 1)
+	{
+		DEBUG_PRINT("fwrite returned %ld [!= 1]\n", size);
+		int err = ferror(file);
+		if (err != 0) {
+			return err;
+		}
+		else if (errno != 0)
+		{
+			err = errno;
+			return err;
+		}
+		else
+			return -1;
+	}
+
+	return 0;
+}
+
+
+#ifdef NON_SGX_PROTECTED_FS
+int32_t u_sgxprotectedfs_fclose(FILE* f)
+#else
+int32_t u_sgxprotectedfs_fclose(void* f)
+#endif
+{
+	FILE* file = (FILE*)f;
+	int result = 0;
+	int fd = 0;
+
+	if (file == NULL)
+	{
+		DEBUG_PRINT("file is NULL\n");
+		return -1;
+	}
+
+	// closing the file handle should also remove the lock, but we try to remove it explicitly
+	fd = fileno(file);
+	if (fd == -1)
+		DEBUG_PRINT("fileno returned -1\n");
+	else
+		flock(fd, LOCK_UN);
+	
+	if ((result = fclose(file)) != 0)
+	{
+		if (errno != 0)
+		{
+			int err = errno;
+			DEBUG_PRINT("fclose returned %d, errno: %d\n", result, err);
+			return err;
+		}
+		DEBUG_PRINT("fclose returned %d\n", result);
+		return -1;
+	}
+
+	return 0;
+}
+
+
+#ifdef NON_SGX_PROTECTED_FS
+uint8_t u_sgxprotectedfs_fflush(FILE* f)
+#else
+uint8_t u_sgxprotectedfs_fflush(void* f)
+#endif
+{
+	FILE* file = (FILE*)f;
+	int result;
+
+	if (file == NULL)
+	{
+		DEBUG_PRINT("file is NULL\n");
+		return 1;
+	}
+	
+	if ((result = fflush(file)) != 0)
+	{
+		DEBUG_PRINT("fflush returned %d\n", result);
+		return 1;
+	}
+	
+	return 0;
+}
+
+
+int32_t u_sgxprotectedfs_remove(const char* filename)
+{
+	int result;
+
+	if (filename == NULL || strnlen(filename, 1) == 0)
+	{
+		DEBUG_PRINT("filename is NULL or empty\n");
+		return -1;
+	}
+
+	if ((result = remove(filename)) != 0)
+	{// this function is called from the destructor which is called when calling fclose, if there were no writes, there is no recovery file...we don't want endless prints...
+		//DEBUG_PRINT("remove returned %d\n", result);
+		if (errno != 0)
+			return errno;
+		return -1;
+	}
+	
+	return 0;
+}
+
+#define MILISECONDS_SLEEP_FOPEN 10
+#define MAX_FOPEN_RETRIES       10
+#ifdef NON_SGX_PROTECTED_FS
+FILE* u_sgxprotectedfs_recovery_file_open(const char* filename)
+#else
+void* u_sgxprotectedfs_recovery_file_open(const char* filename)
+#endif
+{
+	FILE* f = NULL;
+
+	if (filename == NULL || strnlen(filename, 1) == 0)
+	{
+		DEBUG_PRINT("recovery filename is NULL or empty\n");
+		return NULL;
+	}
+	
+	for (int i = 0; i < MAX_FOPEN_RETRIES; i++)
+	{
+		f = fopen(filename, "wb");
+		if (f != NULL)
+			break;
+		usleep(MILISECONDS_SLEEP_FOPEN);
+	}
+	if (f == NULL)
+	{
+		DEBUG_PRINT("fopen (%s) returned NULL\n", filename);
+		return NULL;
+	}
+	
+	return f;
+}
+
+
+#ifdef NON_SGX_PROTECTED_FS
+uint8_t u_sgxprotectedfs_fwrite_recovery_node(FILE* f, uint8_t* data, uint32_t data_length)
+#else
+uint8_t u_sgxprotectedfs_fwrite_recovery_node(void* f, uint8_t* data, uint32_t data_length)
+#endif
+{
+	FILE* file = (FILE*)f;
+
+	if (file == NULL)
+	{
+		DEBUG_PRINT("file is NULL\n");
+		return 1;
+	}
+		
+	// recovery nodes are written sequentially
+	size_t count = fwrite(data, 1, data_length, file);
+	if (count != data_length)
+	{
+		DEBUG_PRINT("fwrite returned %ld instead of %d\n", count, data_length);
+		return 1;
+	}
+
+	return 0;
+}
+
+
+int32_t u_sgxprotectedfs_do_file_recovery(const char* filename, const char* recovery_filename, uint32_t node_size)
+{
+	FILE* recovery_file = NULL;
+	FILE* source_file = NULL;
+	int32_t ret = -1;
+	uint32_t nodes_count = 0;
+	uint32_t recovery_node_size = (uint32_t)(sizeof(uint64_t)) + node_size; // node offset + data
+	uint64_t file_size = 0;
+	int err = 0;
+	int result = 0;
+	size_t count = 0;
+	uint8_t* recovery_node = NULL;
+	uint32_t i = 0;
+
+	do 
+	{
+		if (filename == NULL || strnlen(filename, 1) == 0)
+		{
+			DEBUG_PRINT("filename is NULL or empty\n");
+			return (int32_t)NULL;
+		}
+
+		if (recovery_filename == NULL || strnlen(recovery_filename, 1) == 0)
+		{
+			DEBUG_PRINT("recovery filename is NULL or empty\n");
+			return (int32_t)NULL;
+		}
+	
+		recovery_file = fopen(recovery_filename, "rb");
+		if (recovery_file == NULL)
+		{
+			DEBUG_PRINT("fopen of recovery file returned NULL - no recovery file exists\n");
+			ret = -1;
+			break;
+		}
+
+		if ((result = fseeko(recovery_file, 0, SEEK_END)) != 0)
+		{
+			DEBUG_PRINT("fseeko returned %d\n", result);
+			if (errno != 0)
+				ret = errno;
+			break;
+		}
+
+		file_size = ftello(recovery_file);
+	
+		if ((result = fseeko(recovery_file, 0, SEEK_SET)) != 0)
+		{
+			DEBUG_PRINT("fseeko returned %d\n", result);
+			if (errno != 0)
+				ret = errno;
+			break;
+		}
+
+		if (file_size % recovery_node_size != 0)
+		{
+			// corrupted recovery file
+			DEBUG_PRINT("recovery file size is not the right size [%lu]\n", file_size);
+			ret = ENOTSUP;
+			break;
+		}
+
+		nodes_count = (uint32_t)(file_size / recovery_node_size);
+
+		recovery_node = (uint8_t*)malloc(recovery_node_size);
+		if (recovery_node == NULL)
+		{
+			DEBUG_PRINT("malloc failed\n");
+			ret = ENOMEM;
+			break;
+		}
+
+		source_file = fopen(filename, "r+b");
+		if (source_file == NULL)
+		{
+			DEBUG_PRINT("fopen returned NULL\n");
+			ret = -1;
+			break;
+		}
+
+		for (i = 0 ; i < nodes_count ; i++)
+		{
+			if ((count = fread(recovery_node, recovery_node_size, 1, recovery_file)) != 1)
+			{
+				DEBUG_PRINT("fread returned %ld [!= 1]\n", count);
+				err = ferror(recovery_file);
+				if (err != 0)
+					ret = err;
+				else if (errno != 0) 
+					ret = errno;
+				break;
+			}
+
+			// seek the regular file to the required offset
+			if ((result = fseeko(source_file, (*((uint64_t*)recovery_node)) * node_size, SEEK_SET)) != 0)
+			{
+				DEBUG_PRINT("fseeko returned %d\n", result);
+				if (errno != 0)
+					ret = errno;
+				break;
+			}
+
+			// write down the original data from the recovery file
+			if ((count = fwrite(&recovery_node[sizeof(uint64_t)], node_size, 1, source_file)) != 1)
+			{
+				DEBUG_PRINT("fwrite returned %ld [!= 1]\n", count);
+				err = ferror(source_file);
+				if (err != 0)
+					ret = err;
+				else if (errno != 0) 
+					ret = errno;
+				break;
+			}
+		}
+
+		if (i != nodes_count) // the 'for' loop exited with error
+			break;
+
+		if ((result = fflush(source_file)) != 0)
+		{
+			DEBUG_PRINT("fflush returned %d\n", result);
+			ret = result;
+			break;
+		}
+
+		ret = 0;
+
+	} while(0);
+
+	if (recovery_node != NULL)
+		free(recovery_node);
+
+	if (source_file != NULL)
+	{
+		result = fclose(source_file);
+		assert(result == 0);
+	}
+
+	if (recovery_file != NULL)
+	{
+		result = fclose(recovery_file);
+		assert(result == 0);
+	}
+
+	if (ret == 0)
+		remove(recovery_filename);
+	
+	return ret;
+}

--- a/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_uprotected_fs/uprotected_fs.h
+++ b/mesatee_utils/protected_fs_rs/protected_fs_c/sgx_uprotected_fs/uprotected_fs.h
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod common_setup;
-pub mod kms_test;
-pub mod protected_fs_test;
-pub mod tdfs_test;
-pub mod tms_test;
+#ifndef _UPROTECTED_FS_H_
+#define _UPROTECTED_FS_H_
+
+// this file should remain empty in release environment
+// validation environment will provide a different version of this file
+
+
+#endif	// _UPROTECTED_FS_H_

--- a/mesatee_utils/protected_fs_rs/src/deps.rs
+++ b/mesatee_utils/protected_fs_rs/src/deps.rs
@@ -1,0 +1,53 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![allow(non_camel_case_types)]
+
+use cfg_if::cfg_if;
+cfg_if! {
+    if #[cfg(feature = "mesalock_sgx")] {
+        pub(crate) use sgx_trts::libc;
+        pub(crate) use sgx_trts::libc::c_void;
+        pub(crate) use sgx_trts::c_str::CStr;
+
+        pub(crate) use sgx_types::size_t;
+        pub(crate) use sgx_types::sgx_key_128bit_t;
+
+        pub(crate) use sgx_types::{c_char, c_int};
+        pub(crate) use sgx_types::{int32_t, int64_t};
+        pub(crate) use sgx_types::{SysError, SysResult};
+        pub(crate) use sgx_trts::error::errno;
+
+        pub(crate) use core::cmp;
+    } else {
+        pub(crate) use libc;
+        pub(crate) use std::ffi::c_void;
+        pub(crate) use std::ffi::CStr;
+
+        pub(crate) use libc::size_t;
+        pub(crate) type sgx_key_128bit_t = [u8; 16];
+
+        pub(crate) use std::os::raw::{c_char, c_int};
+        pub(crate) type int32_t = i32;
+        pub(crate) type int64_t = i64;
+        pub(crate) type sys_error_t = int32_t;
+        pub(crate) type SysError = std::result::Result<(), sys_error_t>;
+        pub(crate) type SysResult<T> = std::result::Result<T, sys_error_t>;
+
+        pub(crate) fn errno() -> i32 {
+            std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
+        }
+
+        pub(crate) use std::cmp;
+    }
+}

--- a/mesatee_utils/protected_fs_rs/src/lib.rs
+++ b/mesatee_utils/protected_fs_rs/src/lib.rs
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod common_setup;
-pub mod kms_test;
-pub mod protected_fs_test;
-pub mod tdfs_test;
-pub mod tms_test;
+#![cfg_attr(feature = "mesalock_sgx", no_std)]
+#[cfg(feature = "mesalock_sgx")]
+#[macro_use]
+extern crate sgx_tstd as std;
+
+mod deps;
+mod protected_fs;
+mod sgx_fs_inner;
+mod sgx_tprotected_fs;
+pub use crate::protected_fs::*;

--- a/mesatee_utils/protected_fs_rs/src/protected_fs.rs
+++ b/mesatee_utils/protected_fs_rs/src/protected_fs.rs
@@ -1,0 +1,301 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Filesystem manipulation operations.
+
+#[cfg(feature = "mesalock_sgx")]
+use std::prelude::v1::*;
+
+use crate::deps::sgx_key_128bit_t;
+use crate::sgx_fs_inner as fs_imp;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+/// A reference to an open file on the filesystem.
+///
+/// An instance of a `File` can be read and/or written depending on what options
+/// it was opened with. Files also implement [`Seek`] to alter the logical cursor
+/// that the file contains internally.
+///
+/// Files are automatically closed when they go out of scope.
+pub struct ProtectedFile {
+    inner: fs_imp::SgxFile,
+}
+
+/// Options and flags which can be used to configure how a file is opened.
+///
+/// This builder exposes the ability to configure how a ProtectedFile is opened and
+/// what operations are permitted on the open file. The ProtectedFile::open and
+/// ProtectedFile::create methods are aliases for commonly used options using this
+/// builder.
+///
+#[derive(Clone, Debug)]
+pub struct OpenOptions(fs_imp::OpenOptions);
+
+impl ProtectedFile {
+    #[cfg(feature = "mesalock_sgx")]
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<ProtectedFile> {
+        OpenOptions::default().read(true).open(path.as_ref())
+    }
+
+    #[cfg(feature = "mesalock_sgx")]
+    pub fn create<P: AsRef<Path>>(path: P) -> io::Result<ProtectedFile> {
+        OpenOptions::default().write(true).open(path.as_ref())
+    }
+
+    pub fn open_ex<P: AsRef<Path>>(path: P, key: &sgx_key_128bit_t) -> io::Result<ProtectedFile> {
+        OpenOptions::default()
+            .read(true)
+            .open_ex(path.as_ref(), key)
+    }
+
+    pub fn create_ex<P: AsRef<Path>>(path: P, key: &sgx_key_128bit_t) -> io::Result<ProtectedFile> {
+        OpenOptions::default()
+            .write(true)
+            .open_ex(path.as_ref(), key)
+    }
+
+    pub fn is_eof(&self) -> bool {
+        self.inner.is_eof()
+    }
+
+    pub fn clearerr(&self) {
+        self.inner.clearerr()
+    }
+
+    pub fn clear_cache(&self) -> io::Result<()> {
+        self.inner.clear_cache()
+    }
+}
+
+impl Read for ProtectedFile {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl Write for ProtectedFile {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl Seek for ProtectedFile {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.inner.seek(pos)
+    }
+}
+
+impl<'a> Read for &'a ProtectedFile {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl<'a> Write for &'a ProtectedFile {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl<'a> Seek for &'a ProtectedFile {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.inner.seek(pos)
+    }
+}
+
+impl OpenOptions {
+    /// Creates a blank new set of options ready for configuration.
+    ///
+    /// All options are initially set to `false`.
+    ///
+    pub fn default() -> OpenOptions {
+        OpenOptions(fs_imp::OpenOptions::new())
+    }
+
+    /// Sets the option for read access.
+    ///
+    /// This option, when true, will indicate that the file should be
+    /// `read`-able if opened.
+    ///
+    pub fn read(&mut self, read: bool) -> &mut OpenOptions {
+        self.0.read(read);
+        self
+    }
+
+    /// Sets the option for write access.
+    ///
+    /// This option, when true, will indicate that the file should be
+    /// `write`-able if opened.
+    ///
+    pub fn write(&mut self, write: bool) -> &mut OpenOptions {
+        self.0.write(write);
+        self
+    }
+
+    /// Sets the option for the append mode.
+    ///
+    /// This option, when true, means that writes will append to a file instead
+    /// of overwriting previous contents.
+    /// Note that setting `.write(true).append(true)` has the same effect as
+    /// setting only `.append(true)`.
+    ///
+    /// For most filesystems, the operating system guarantees that all writes are
+    /// atomic: no writes get mangled because another process writes at the same
+    /// time.
+    ///
+    /// One maybe obvious note when using append-mode: make sure that all data
+    /// that belongs together is written to the file in one operation. This
+    /// can be done by concatenating strings before passing them to `write()`,
+    /// or using a buffered writer (with a buffer of adequate size),
+    /// and calling `flush()` when the message is complete.
+    ///
+    /// If a file is opened with both read and append access, beware that after
+    /// opening, and after every write, the position for reading may be set at the
+    /// end of the file. So, before writing, save the current position (using
+    /// `seek(SeekFrom::Current(0))`, and restore it before the next read.
+    ///
+    pub fn append(&mut self, append: bool) -> &mut OpenOptions {
+        self.0.append(append);
+        self
+    }
+
+    /// Sets the option for update a previous file.
+    pub fn update(&mut self, update: bool) -> &mut OpenOptions {
+        self.0.update(update);
+        self
+    }
+
+    /// Sets the option for binary a file.
+    pub fn binary(&mut self, binary: bool) -> &mut OpenOptions {
+        self.0.binary(binary);
+        self
+    }
+
+    /// Opens a file at `path` with the options specified by `self`.
+    pub fn open<P: AsRef<Path>>(&self, path: P) -> io::Result<ProtectedFile> {
+        self._open(path.as_ref())
+    }
+
+    pub fn open_ex<P: AsRef<Path>>(
+        &self,
+        path: P,
+        key: &sgx_key_128bit_t,
+    ) -> io::Result<ProtectedFile> {
+        self._open_ex(path.as_ref(), key)
+    }
+
+    fn _open(&self, path: &Path) -> io::Result<ProtectedFile> {
+        let inner = fs_imp::SgxFile::open(path, &self.0)?;
+        Ok(ProtectedFile { inner })
+    }
+
+    fn _open_ex(&self, path: &Path, key: &sgx_key_128bit_t) -> io::Result<ProtectedFile> {
+        let inner = fs_imp::SgxFile::open_ex(path, &self.0, key)?;
+        Ok(ProtectedFile { inner })
+    }
+}
+
+pub fn remove_protected_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    fs_imp::remove(path.as_ref())
+}
+
+#[cfg(feature = "mesalock_sgx")]
+pub fn export_auto_key<P: AsRef<Path>>(path: P) -> io::Result<sgx_key_128bit_t> {
+    fs_imp::export_auto_key(path.as_ref())
+}
+
+#[cfg(feature = "mesalock_sgx")]
+pub fn import_auto_key<P: AsRef<Path>>(path: P, key: &sgx_key_128bit_t) -> io::Result<()> {
+    fs_imp::import_auto_key(path.as_ref(), key)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::remove_protected_file;
+    use crate::ProtectedFile;
+    use rand::prelude::RngCore;
+    use std::io::{Read, Write};
+
+    #[test]
+    pub fn test_sgxfs() {
+        let key = [90u8; 16];
+
+        let mut write_data: [u8; 16] = [0; 16];
+        let mut read_data: [u8; 16] = [0; 16];
+        let write_size;
+        let read_size;
+        {
+            let mut rng = rand::thread_rng();
+            rng.fill_bytes(&mut write_data);
+
+            let opt = ProtectedFile::create_ex("sgx_file", &key);
+            assert_eq!(opt.is_ok(), true);
+            let mut file = opt.unwrap();
+
+            let result = file.write(&write_data);
+            assert_eq!(result.is_ok(), true);
+            write_size = result.unwrap();
+        }
+
+        {
+            let opt = ProtectedFile::open_ex("sgx_file", &key);
+            assert_eq!(opt.is_ok(), true);
+            let mut file = opt.unwrap();
+
+            let result = file.read(&mut read_data);
+            assert_eq!(result.is_ok(), true);
+            read_size = result.unwrap();
+        }
+
+        let result = remove_protected_file("sgx_file");
+        assert_eq!(result.is_ok(), true);
+
+        assert_eq!(write_data, read_data);
+        assert_eq!(write_size, read_size);
+
+        {
+            let opt = ProtectedFile::open_ex("/", &key);
+            assert_eq!(opt.is_err(), true);
+            let opt = ProtectedFile::open_ex(".", &key);
+            assert_eq!(opt.is_err(), true);
+            let opt = ProtectedFile::open_ex("..", &key);
+            assert_eq!(opt.is_err(), true);
+            let opt = ProtectedFile::open_ex("?", &key);
+            assert_eq!(opt.is_err(), true);
+        }
+        {
+            let opt = ProtectedFile::open_ex("/dev/isgx", &key);
+            assert_eq!(opt.is_ok(), true);
+        }
+        {
+            let opt = ProtectedFile::create_ex("/", &key);
+            assert_eq!(opt.is_err(), true);
+        }
+        {
+            let opt = ProtectedFile::create_ex("/proc/100", &key);
+            assert_eq!(opt.is_err(), true);
+            let opt = ProtectedFile::create_ex(".", &key);
+            assert_eq!(opt.is_err(), true);
+            let opt = ProtectedFile::create_ex("..", &key);
+            assert_eq!(opt.is_err(), true);
+        }
+    }
+}

--- a/mesatee_utils/protected_fs_rs/src/sgx_fs_inner.rs
+++ b/mesatee_utils/protected_fs_rs/src/sgx_fs_inner.rs
@@ -1,0 +1,179 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "mesalock_sgx")]
+use std::prelude::v1::*;
+
+use std::ffi::{CStr, CString};
+use std::io::{self, Error, SeekFrom};
+use std::path::Path;
+
+use crate::deps::libc;
+use crate::deps::sgx_key_128bit_t;
+
+use crate::sgx_tprotected_fs::{self, SgxFileStream};
+pub struct SgxFile(SgxFileStream);
+
+#[derive(Clone, Debug)]
+pub struct OpenOptions {
+    read: bool,
+    write: bool,
+    append: bool,
+    update: bool,
+    binary: bool,
+}
+
+impl OpenOptions {
+    pub fn new() -> OpenOptions {
+        OpenOptions {
+            read: false,
+            write: false,
+            append: false,
+            update: false,
+            binary: false,
+        }
+    }
+
+    pub fn read(&mut self, read: bool) {
+        self.read = read;
+    }
+    pub fn write(&mut self, write: bool) {
+        self.write = write;
+    }
+    pub fn append(&mut self, append: bool) {
+        self.append = append;
+    }
+    pub fn update(&mut self, update: bool) {
+        self.update = update;
+    }
+    pub fn binary(&mut self, binary: bool) {
+        self.binary = binary;
+    }
+
+    fn get_access_mode(&self) -> io::Result<String> {
+        let mut mode = match (self.read, self.write, self.append) {
+            (true, false, false) => "r".to_string(),
+            (false, true, false) => "w".to_string(),
+            (false, false, true) => "a".to_string(),
+            _ => return Err(Error::from_raw_os_error(libc::EINVAL)),
+        };
+        if self.update {
+            mode += "+";
+        }
+        if self.binary {
+            mode += "b";
+        }
+        Ok(mode)
+    }
+}
+
+impl SgxFile {
+    pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<SgxFile> {
+        let path = cstr(path)?;
+        let mode = opts.get_access_mode()?;
+        let opts = CString::new(mode.as_bytes())?;
+        SgxFile::open_c(&path, &opts, &sgx_key_128bit_t::default(), true)
+    }
+
+    pub fn open_ex(path: &Path, opts: &OpenOptions, key: &sgx_key_128bit_t) -> io::Result<SgxFile> {
+        let path = cstr(path)?;
+        let mode = opts.get_access_mode()?;
+        let opts = CString::new(mode.as_bytes())?;
+        SgxFile::open_c(&path, &opts, key, false)
+    }
+
+    pub fn open_c(
+        path: &CStr,
+        opts: &CStr,
+        key: &sgx_key_128bit_t,
+        auto: bool,
+    ) -> io::Result<SgxFile> {
+        let file = if auto {
+            SgxFileStream::open_auto_key(path, opts)
+        } else {
+            SgxFileStream::open(path, opts, key)
+        };
+
+        file.map(SgxFile).map_err(Error::from_raw_os_error)
+    }
+
+    pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf).map_err(Error::from_raw_os_error)
+    }
+
+    pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf).map_err(Error::from_raw_os_error)
+    }
+
+    pub fn tell(&self) -> io::Result<u64> {
+        self.0
+            .tell()
+            .map_err(Error::from_raw_os_error)
+            .map(|offset| offset as u64)
+    }
+
+    pub fn seek(&self, pos: SeekFrom) -> io::Result<u64> {
+        let (whence, offset) = match pos {
+            SeekFrom::Start(off) => (sgx_tprotected_fs::SeekFrom::Start, off as i64),
+            SeekFrom::End(off) => (sgx_tprotected_fs::SeekFrom::End, off),
+            SeekFrom::Current(off) => (sgx_tprotected_fs::SeekFrom::Current, off),
+        };
+
+        r#try!(self
+            .0
+            .seek(offset, whence)
+            .map_err(|err| { Error::from_raw_os_error(err) }));
+
+        let offset = r#try!(self.tell());
+        Ok(offset as u64)
+    }
+
+    pub fn flush(&self) -> io::Result<()> {
+        self.0.flush().map_err(Error::from_raw_os_error)
+    }
+
+    pub fn is_eof(&self) -> bool {
+        self.0.is_eof()
+    }
+
+    pub fn clearerr(&self) {
+        self.0.clearerr()
+    }
+
+    pub fn clear_cache(&self) -> io::Result<()> {
+        self.0.clear_cache().map_err(Error::from_raw_os_error)
+    }
+}
+
+pub fn remove(path: &Path) -> io::Result<()> {
+    let path = cstr(path)?;
+    sgx_tprotected_fs::remove(&path).map_err(Error::from_raw_os_error)
+}
+
+#[cfg(feature = "mesalock_sgx")]
+pub fn export_auto_key(path: &Path) -> io::Result<sgx_key_128bit_t> {
+    let path = cstr(path)?;
+    sgx_tprotected_fs::export_auto_key(&path).map_err(Error::from_raw_os_error)
+}
+
+#[cfg(feature = "mesalock_sgx")]
+pub fn import_auto_key(path: &Path, key: &sgx_key_128bit_t) -> io::Result<()> {
+    let path = cstr(path)?;
+    sgx_tprotected_fs::import_auto_key(&path, key).map_err(Error::from_raw_os_error)
+}
+
+use std::os::unix::ffi::OsStrExt;
+fn cstr(path: &Path) -> io::Result<CString> {
+    Ok(CString::new(path.as_os_str().as_bytes())?)
+}

--- a/mesatee_utils/protected_fs_rs/src/sgx_tprotected_fs.rs
+++ b/mesatee_utils/protected_fs_rs/src/sgx_tprotected_fs.rs
@@ -1,0 +1,695 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![allow(non_camel_case_types)]
+
+#[cfg(feature = "mesalock_sgx")]
+use std::prelude::v1::*;
+
+use crate::deps::c_void;
+use crate::deps::cmp;
+use crate::deps::errno;
+use crate::deps::libc;
+use crate::deps::sgx_key_128bit_t;
+use crate::deps::size_t;
+use crate::deps::CStr;
+use crate::deps::{c_char, c_int};
+use crate::deps::{int32_t, int64_t};
+use crate::deps::{SysError, SysResult};
+
+pub type SGX_FILE = *mut c_void;
+
+extern "C" {
+    //
+    // sgx_tprotected_fs.h
+    //
+    pub fn sgx_fopen(
+        filename: *const c_char,
+        mode: *const c_char,
+        key: *const sgx_key_128bit_t,
+    ) -> SGX_FILE;
+
+    pub fn sgx_fopen_auto_key(filename: *const c_char, mode: *const c_char) -> SGX_FILE;
+
+    pub fn sgx_fwrite(ptr: *const c_void, size: size_t, count: size_t, stream: SGX_FILE) -> size_t;
+
+    pub fn sgx_fread(ptr: *mut c_void, size: size_t, count: size_t, stream: SGX_FILE) -> size_t;
+
+    pub fn sgx_ftell(stream: SGX_FILE) -> int64_t;
+
+    pub fn sgx_fseek(stream: SGX_FILE, offset: int64_t, origin: c_int) -> int32_t;
+
+    pub fn sgx_fflush(stream: SGX_FILE) -> int32_t;
+
+    pub fn sgx_ferror(stream: SGX_FILE) -> int32_t;
+
+    pub fn sgx_feof(stream: SGX_FILE) -> int32_t;
+
+    pub fn sgx_clearerr(stream: SGX_FILE);
+
+    pub fn sgx_fclose(stream: SGX_FILE) -> int32_t;
+
+    pub fn sgx_remove(filename: *const c_char) -> int32_t;
+
+    #[cfg(feature = "mesalock_sgx")]
+    pub fn sgx_fexport_auto_key(filename: *const c_char, key: *mut sgx_key_128bit_t) -> int32_t;
+
+    #[cfg(feature = "mesalock_sgx")]
+    pub fn sgx_fimport_auto_key(filename: *const c_char, key: *const sgx_key_128bit_t) -> int32_t;
+
+    pub fn sgx_fclear_cache(stream: SGX_FILE) -> int32_t;
+}
+
+fn max_len() -> usize {
+    u32::max_value() as usize
+}
+
+unsafe fn rsgx_fopen(filename: &CStr, mode: &CStr, key: &sgx_key_128bit_t) -> SysResult<SGX_FILE> {
+    let file = sgx_fopen(
+        filename.as_ptr(),
+        mode.as_ptr(),
+        key as *const sgx_key_128bit_t,
+    );
+    if file.is_null() {
+        Err(errno())
+    } else {
+        Ok(file)
+    }
+}
+
+unsafe fn rsgx_fopen_auto_key(filename: &CStr, mode: &CStr) -> SysResult<SGX_FILE> {
+    let file = sgx_fopen_auto_key(filename.as_ptr(), mode.as_ptr());
+    if file.is_null() {
+        Err(errno())
+    } else {
+        Ok(file)
+    }
+}
+
+unsafe fn rsgx_fwrite(stream: SGX_FILE, buf: &[u8]) -> SysResult<usize> {
+    if stream.is_null() || buf.is_empty() {
+        return Err(libc::EINVAL);
+    }
+
+    let write_size = cmp::min(buf.len(), max_len());
+    let ret_size = sgx_fwrite(buf.as_ptr() as *const c_void, 1, write_size, stream);
+    if ret_size != write_size {
+        Err(rsgx_ferror(stream))
+    } else {
+        Ok(ret_size)
+    }
+}
+
+unsafe fn rsgx_fread(stream: SGX_FILE, buf: &mut [u8]) -> SysResult<usize> {
+    if stream.is_null() || buf.is_empty() {
+        return Err(libc::EINVAL);
+    }
+
+    let read_size = cmp::min(buf.len(), max_len());
+    let ret_size = sgx_fread(buf.as_mut_ptr() as *mut c_void, 1, read_size, stream);
+
+    if ret_size != read_size {
+        let is_eof = r#try!(rsgx_feof(stream));
+        if is_eof {
+            Ok(ret_size)
+        } else {
+            Err(rsgx_ferror(stream))
+        }
+    } else {
+        Ok(ret_size)
+    }
+}
+
+unsafe fn rsgx_ftell(stream: SGX_FILE) -> SysResult<i64> {
+    if stream.is_null() {
+        return Err(libc::EINVAL);
+    }
+
+    let pos = sgx_ftell(stream);
+    if pos == -1 {
+        Err(errno())
+    } else {
+        Ok(pos)
+    }
+}
+
+unsafe fn rsgx_fseek(stream: SGX_FILE, offset: i64, origin: i32) -> SysError {
+    if stream.is_null() {
+        return Err(libc::EINVAL);
+    }
+
+    let ret = sgx_fseek(stream, offset, origin);
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(rsgx_ferror(stream))
+    }
+}
+
+unsafe fn rsgx_fflush(stream: SGX_FILE) -> SysError {
+    let ret = sgx_fflush(stream);
+    if ret == 0 {
+        Ok(())
+    } else if ret == libc::EOF {
+        Err(rsgx_ferror(stream))
+    } else {
+        Err(ret)
+    }
+}
+
+unsafe fn rsgx_ferror(stream: SGX_FILE) -> i32 {
+    let mut err = sgx_ferror(stream);
+    if err == -1 {
+        err = libc::EINVAL;
+    }
+    err
+}
+
+unsafe fn rsgx_feof(stream: SGX_FILE) -> SysResult<bool> {
+    if stream.is_null() {
+        return Err(libc::EINVAL);
+    }
+
+    if sgx_feof(stream) == 1 {
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+unsafe fn rsgx_clearerr(stream: SGX_FILE) {
+    sgx_clearerr(stream)
+}
+
+unsafe fn rsgx_fclose(stream: SGX_FILE) -> SysError {
+    if stream.is_null() {
+        return Err(libc::EINVAL);
+    }
+
+    let ret = sgx_fclose(stream);
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(libc::EIO)
+    }
+}
+
+unsafe fn rsgx_fclear_cache(stream: SGX_FILE) -> SysError {
+    if stream.is_null() {
+        return Err(libc::EINVAL);
+    }
+
+    let ret = sgx_fclear_cache(stream);
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(rsgx_ferror(stream))
+    }
+}
+
+unsafe fn rsgx_remove(filename: &CStr) -> SysError {
+    let ret = sgx_remove(filename.as_ptr());
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(errno())
+    }
+}
+
+#[cfg(feature = "mesalock_sgx")]
+unsafe fn rsgx_fexport_auto_key(filename: &CStr, key: &mut sgx_key_128bit_t) -> SysError {
+    let ret = sgx_fexport_auto_key(filename.as_ptr(), key as *mut sgx_key_128bit_t);
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(errno())
+    }
+}
+
+#[cfg(feature = "mesalock_sgx")]
+unsafe fn rsgx_fimport_auto_key(filename: &CStr, key: &sgx_key_128bit_t) -> SysError {
+    let ret = sgx_fimport_auto_key(filename.as_ptr(), key as *const sgx_key_128bit_t);
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(errno())
+    }
+}
+
+pub struct SgxFileStream {
+    stream: SGX_FILE,
+}
+
+impl SgxFileStream {
+    ///
+    /// The open function creates or opens a protected file.
+    ///
+    /// # Description
+    ///
+    /// open is similar to the C file API fopen. It creates a new Protected File or opens an existing
+    /// Protected File created with a previous call to open. Regular files cannot be opened with this API.
+    ///
+    /// # Parameters
+    ///
+    /// **filename**
+    ///
+    /// The name of the file to be created or opened.
+    ///
+    /// **mode**
+    ///
+    /// The file open mode string. Allowed values are any combination of ‘r’, ‘w’ or ‘a’, with possible ‘+’
+    /// and possible ‘b’ (since string functions are currently not sup- ported, ‘b’ is meaningless).
+    ///
+    /// **key**
+    ///
+    /// The encryption key of the file. This key is used as a key derivation key, used for deriving encryption
+    /// keys for the file. If the file is created with open, you should protect this key and provide it as
+    /// input every time the file is opened.
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// If the function succeeds, it returns a valid file pointer, which can be used by all the other functions
+    /// in the Protected FS API, otherwise, error code is returned.
+    ///
+    pub fn open(filename: &CStr, mode: &CStr, key: &sgx_key_128bit_t) -> SysResult<SgxFileStream> {
+        unsafe { rsgx_fopen(filename, mode, key).map(|f| SgxFileStream { stream: f }) }
+    }
+
+    ///
+    /// The open_auto_key function creates or opens a protected file.
+    ///
+    /// # Description
+    ///
+    /// open_auto_key is similar to the C file API fopen. It creates a new Protected File or opens an existing
+    /// Protected File created with a previous call to open_auto_key. Regular files cannot be opened with this API.
+    ///
+    /// # Parameters
+    ///
+    /// **filename**
+    ///
+    /// The name of the file to be created or opened.
+    ///
+    /// **mode**
+    ///
+    /// The file open mode string. Allowed values are any combination of ‘r’, ‘w’ or ‘a’, with possible ‘+’
+    /// and possible ‘b’ (since string functions are currently not sup- ported, ‘b’ is meaningless).
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// If the function succeeds, it returns a valid file pointer, which can be used by all the other functions
+    /// in the Protected FS API, otherwise, error code is returned.
+    ///
+    pub fn open_auto_key(filename: &CStr, mode: &CStr) -> SysResult<SgxFileStream> {
+        unsafe { rsgx_fopen_auto_key(filename, mode).map(|f| SgxFileStream { stream: f }) }
+    }
+
+    ///
+    /// The read function reads the requested amount of data from the file, and extends the file pointer by that amount.
+    ///
+    /// # Description
+    ///
+    /// read is similar to the file API fread. In case of an error, error can be called to get the error code.
+    ///
+    /// # Parameters
+    ///
+    /// **buf**
+    ///
+    /// A pointer to a buffer to receive the data read from the file.
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// If the function succeeds, the number of bytes read is returned (zero indicates end of file).
+    /// otherwise, error code is returned.
+    ///
+    pub fn read(&self, buf: &mut [u8]) -> SysResult<usize> {
+        unsafe { rsgx_fread(self.stream, buf) }
+    }
+
+    ///
+    /// The write function writes the given amount of data to the file, and extends the file pointer by that amount.
+    ///
+    /// # Description
+    ///
+    /// write is similar to the file API fwrite. In case of an error, error can be called to get the error code.
+    ///
+    /// # Parameters
+    ///
+    /// **buf**
+    ///
+    /// A pointer to a buffer, that contains the data to write to the file.
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// If the function succeeds, the number of bytes written is returned (zero indicates nothing was written).
+    /// otherwise, error code is returned.
+    ///
+    pub fn write(&self, buf: &[u8]) -> SysResult<usize> {
+        unsafe { rsgx_fwrite(self.stream, buf) }
+    }
+
+    ///
+    /// The tell function obtains the current value of the file position indicator for the stream pointed to by stream.
+    ///
+    /// # Description
+    ///
+    /// tell is similar to the C file API ftell.
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// If the function succeeds, it returns the current value of the position indicator of the file.
+    /// otherwise, error code is returned.
+    ///
+    pub fn tell(&self) -> SysResult<i64> {
+        unsafe { rsgx_ftell(self.stream) }
+    }
+
+    ///
+    /// The seek function sets the current value of the position indicator of the file.
+    ///
+    /// # Description
+    ///
+    /// seek is similar to the C file API fseek.
+    ///
+    /// # Parameters
+    ///
+    /// **offset**
+    ///
+    /// The new required value, relative to the origin parameter.
+    ///
+    /// **origin**
+    ///
+    /// The origin from which to calculate the offset (Start, ENd or Current).
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// If the function failed, error code is returned.
+    ///
+    pub fn seek(&self, offset: i64, origin: SeekFrom) -> SysError {
+        let whence = match origin {
+            SeekFrom::Start => libc::SEEK_SET,
+            SeekFrom::End => libc::SEEK_END,
+            SeekFrom::Current => libc::SEEK_CUR,
+        };
+        unsafe { rsgx_fseek(self.stream, offset, whence) }
+    }
+
+    ///
+    /// The flush function forces a cache flush, and if it returns successfully, it is guaranteed
+    /// that your changes are committed to a file on the disk.
+    ///
+    /// # Description
+    ///
+    /// flush is similar to the C file API fflush. This function flushes all the modified data from
+    /// the cache and writes it to a file on the disk. In case of an error, error can be called to
+    /// get the error code. Note that this function does not clear the cache, but only flushes the
+    /// changes to the actual file on the disk. Flushing also happens automatically when the cache
+    /// is full and page eviction is required.
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// If the function failed, error code is returned.
+    ///
+    pub fn flush(&self) -> SysError {
+        unsafe { rsgx_fflush(self.stream) }
+    }
+
+    ///
+    /// The error function returns the latest operation error code.
+    ///
+    /// # Description
+    ///
+    /// error is similar to the C file API ferror. In case the latest operation failed because
+    /// the file is in a bad state, SGX_ERROR_FILE_BAD_STATUS will be returned.
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// The latest operation error code is returned. 0 indicates that no errors occurred.
+    ///
+    /*
+    pub fn error(&self) -> i32 {
+        unsafe{ rsgx_ferror(self.stream) }
+    }
+    */
+
+    ///
+    /// The is_eof function tells the caller if the file's position indicator hit the end of the
+    /// file in a previous read operation.
+    ///
+    /// # Description
+    ///
+    /// is_eof is similar to the C file API feof.
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// true - End of file was not reached. false - End of file was reached.
+    ///
+    pub fn is_eof(&self) -> bool {
+        unsafe { rsgx_feof(self.stream).unwrap() }
+    }
+
+    ///
+    /// The clearerr function attempts to repair a bad file status, and also clears the end-of-file flag.
+    ///
+    /// # Description
+    ///
+    /// clearerr is similar to the C file API clearerr. This function attempts to repair errors resulted
+    /// from the underlying file system, like write errors to the disk (resulting in a full cache thats
+    /// cannot be emptied). Call error or is_eof after a call to this function to learn if it was successful
+    /// or not.
+    ///
+    /// clearerr does not repair errors resulting from a corrupted file, like decryption errors, or from
+    /// memory corruption, etc.
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// None
+    ///
+    pub fn clearerr(&self) {
+        unsafe { rsgx_clearerr(self.stream) }
+    }
+
+    ///
+    /// The clear_cache function is used for clearing the internal file cache. The function scrubs all
+    /// the data from the cache, and releases all the allocated cache memory.
+    ///
+    /// # Description
+    ///
+    /// clear_cache is used to scrub all the data from the cache and release all the allocated cache
+    /// memory. If modified data is found in the cache, it will be written to the file on disk before
+    /// being scrubbed.
+    ///
+    /// This function is especially useful if you do not trust parts of your own enclave (for example,
+    /// external libraries you linked against, etc.) and want to make sure there is as little sensitive
+    /// data in the memory as possible before transferring control to the code they do not trust.
+    /// Note, however, that the SGX_FILE structure itself still holds sensitive data. To remove all
+    /// such data related to the file from memory completely, you should close the file handle.
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// # Return value
+    ///
+    /// If the function failed, error code is returned.
+    ///
+    pub fn clear_cache(&self) -> SysError {
+        unsafe { rsgx_fclear_cache(self.stream) }
+    }
+}
+
+///
+/// The remove function deletes a file from the file system.
+///
+/// # Description
+///
+/// remove is similar to the C file API remove.
+///
+/// # Parameters
+///
+/// **filename**
+///
+/// The name of the file to delete.
+///
+/// # Requirements
+///
+/// Header: sgx_tprotected_fs.edl
+///
+/// Library: libsgx_tprotected_fs.a
+///
+/// # Return value
+///
+/// If the function failed, error code is returned.
+///
+pub fn remove(filename: &CStr) -> SysError {
+    unsafe { rsgx_remove(filename) }
+}
+
+///
+/// The export_auto_key function is used for exporting the latest key used for the file encryption.
+///
+/// # Description
+///
+/// export_auto_key is used to export the last key that was used in the encryption of the file.
+/// With this key you can import the file in a different enclave or system.
+///
+/// # Parameters
+///
+/// **filename**
+///
+/// The name of the file to be exported. This should be the name of a file created with the open_auto_key API.
+///
+/// # Requirements
+///
+/// Header: sgx_tprotected_fs.edl
+///
+/// Library: libsgx_tprotected_fs.a
+///
+/// # Return value
+///
+/// If the function succeeds, it returns the latest encryption key.
+/// otherwise, error code is returned.
+///
+#[cfg(feature = "mesalock_sgx")]
+pub fn export_auto_key(filename: &CStr) -> SysResult<sgx_key_128bit_t> {
+    let mut key: sgx_key_128bit_t = Default::default();
+    unsafe { rsgx_fexport_auto_key(filename, &mut key).map(|_| key) }
+}
+
+///
+/// The import_auto_key function is used for importing a Protected FS auto key file created on
+/// a different enclave or platform.
+///
+/// # Description
+///
+/// import_auto_key is used for importing a Protected FS file. After this call returns successfully,
+/// the file can be opened normally with export_auto_key.
+///
+/// # Parameters
+///
+/// **filename**
+///
+/// The name of the file to be imported. This should be the name of a file created with the
+/// open_auto_key API, on a different enclave or system.
+///
+/// **key**
+///
+/// he encryption key, exported with a call to export_auto_key in the source enclave or system.
+///
+/// # Requirements
+///
+/// Header: sgx_tprotected_fs.edl
+///
+/// Library: libsgx_tprotected_fs.a
+///
+/// # Return value
+///
+/// otherwise, error code is returned.
+///
+#[cfg(feature = "mesalock_sgx")]
+pub fn import_auto_key(filename: &CStr, key: &sgx_key_128bit_t) -> SysError {
+    unsafe { rsgx_fimport_auto_key(filename, key) }
+}
+
+impl Drop for SgxFileStream {
+    fn drop(&mut self) {
+        // Note that errors are ignored when closing a file descriptor. The
+        // reason for this is that if an error occurs we don't actually know if
+        // the file descriptor was closed or not, and if we retried (for
+        // something like EINTR), we might close another valid file descriptor
+        // (opened after we closed ours.
+        let _ = unsafe { rsgx_fclose(self.stream) };
+    }
+}
+
+/// Enumeration of possible methods to seek within an I/O object.
+#[derive(Copy, PartialEq, Eq, Clone, Debug)]
+pub enum SeekFrom {
+    /// Set the offset to the provided number of bytes.
+    Start,
+
+    /// Set the offset to the size of this object plus the specified number of
+    /// bytes.
+    ///
+    /// It is possible to seek beyond the end of an object, but it's an error to
+    /// seek before byte 0.
+    End,
+
+    /// Set the offset to the current position plus the specified number of
+    /// bytes.
+    ///
+    /// It is possible to seek beyond the end of an object, but it's an error to
+    /// seek before byte 0.
+    Current,
+}

--- a/mesatee_utils/protected_fs_rs/tests/large_file.rs
+++ b/mesatee_utils/protected_fs_rs/tests/large_file.rs
@@ -1,0 +1,46 @@
+extern crate protected_fs;
+use protected_fs::{remove_protected_file, ProtectedFile};
+use rand::prelude::RngCore;
+use std::io::{Read, Write};
+
+#[test]
+fn test_large_file() {
+    const BLOCK_SIZE: usize = 2048;
+    const NBLOCKS: usize = 0x100000;
+
+    let key = [90u8; 16];
+
+    let mut write_data = [0u8; BLOCK_SIZE];
+    let mut read_data = [0u8; BLOCK_SIZE];
+    let mut write_size;
+    let mut read_size;
+
+    let mut rng = rand::thread_rng();
+    rng.fill_bytes(&mut write_data);
+    let fname = "large_file";
+
+    {
+        let opt = ProtectedFile::create_ex(fname, &key);
+        assert_eq!(opt.is_ok(), true);
+        let mut file = opt.unwrap();
+        for _i in 0..NBLOCKS {
+            let result = file.write(&write_data);
+            assert_eq!(result.is_ok(), true);
+            write_size = result.unwrap();
+            assert_eq!(write_size, write_data.len());
+        }
+    }
+
+    {
+        let opt = ProtectedFile::open_ex(fname, &key);
+        assert_eq!(opt.is_ok(), true);
+        let mut file = opt.unwrap();
+        for _i in 0..NBLOCKS {
+            let result = file.read(&mut read_data);
+            assert_eq!(result.is_ok(), true);
+            read_size = result.unwrap();
+            assert_eq!(read_size, read_data.len());
+        }
+    }
+    assert_eq!(remove_protected_file(fname).is_ok(), true);
+}

--- a/tests/functional_test/sgx_trusted_lib/Cargo.toml
+++ b/tests/functional_test/sgx_trusted_lib/Cargo.toml
@@ -12,18 +12,20 @@ crate-type = ["staticlib"]
 
 [features]
 default = []
-mesalock_sgx = ["sgx_tstd", "sgx_tunittest", "mesatee_core/mesalock_sgx", "kms_client/mesalock_sgx", "tdfs_internal_client/mesalock_sgx", "tms_internal_client/mesalock_sgx", "tms_internal_proto/mesalock_sgx"]
+mesalock_sgx = ["sgx_tstd", "sgx_tunittest", "mesatee_core/mesalock_sgx", "kms_client/mesalock_sgx", "tdfs_internal_client/mesalock_sgx", "tms_internal_client/mesalock_sgx", "tms_internal_proto/mesalock_sgx", "protected_fs_rs/mesalock_sgx"]
 cov = ["sgx_cov"]
 
 [dependencies]
 cfg-if          = { version = "0.1.9" }
 log             = { version = "0.4.6" }
 env_logger      = { version = "0.6.1" }
+rand            = { version = "0.6.5" }
 
 kms_client      = { path = "../../../mesatee_services/kms/client", optional = true }
 tdfs_internal_client = { path = "../../../mesatee_services/tdfs/internal/client", optional = true }
 tms_internal_client = { path = "../../../mesatee_services/tms/internal/client", optional = true }
 tms_internal_proto = { path = "../../../mesatee_services/tms/internal/proto", optional = true }
+protected_fs_rs    = { path = "../../../mesatee_utils/protected_fs_rs", default-features = false, optional = true }
 
 mesatee_core           = { version = "0.1.0" }
 mesatee_config         = { version = "0.1.0" }

--- a/tests/functional_test/sgx_trusted_lib/src/sgx.rs
+++ b/tests/functional_test/sgx_trusted_lib/src/sgx.rs
@@ -35,6 +35,7 @@ register_ecall_handler!(
 #[handle_ecall]
 fn handle_run_functional_test(_args: &RunFunctionalTestInput) -> Result<RunFunctionalTestOutput> {
     let nfailed = rsgx_unit_tests!(
+        tests::protected_fs_test::read_write_large_file,
         tests::kms_test::api_create_key,
         tests::tdfs_test::read_not_exist_file,
         tests::tdfs_test::save_and_read,

--- a/tests/functional_test/sgx_trusted_lib/src/tests/protected_fs_test.rs
+++ b/tests/functional_test/sgx_trusted_lib/src/tests/protected_fs_test.rs
@@ -1,0 +1,58 @@
+// Copyright 2019 MesaTEE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use protected_fs::{remove_protected_file, ProtectedFile};
+use rand::prelude::RngCore;
+use std::io::{Read, Write};
+
+pub fn read_write_large_file() {
+    const BLOCK_SIZE: usize = 2048;
+    const NBLOCKS: usize = 0x0010_0000;
+
+    let key = [90u8; 16];
+
+    let mut write_data = [0u8; BLOCK_SIZE];
+    let mut read_data = [0u8; BLOCK_SIZE];
+    let mut write_size;
+    let mut read_size;
+
+    let mut rng = rand::thread_rng();
+    rng.fill_bytes(&mut write_data);
+    let fname = "large_file";
+
+    {
+        let opt = ProtectedFile::create_ex(fname, &key);
+        assert_eq!(opt.is_ok(), true);
+        let mut file = opt.unwrap();
+        for _i in 0..NBLOCKS {
+            let result = file.write(&write_data);
+            assert_eq!(result.is_ok(), true);
+            write_size = result.unwrap();
+            assert_eq!(write_size, write_data.len());
+        }
+    }
+
+    {
+        let opt = ProtectedFile::open_ex(fname, &key);
+        assert_eq!(opt.is_ok(), true);
+        let mut file = opt.unwrap();
+        for _i in 0..NBLOCKS {
+            let result = file.read(&mut read_data);
+            assert_eq!(result.is_ok(), true);
+            read_size = result.unwrap();
+            assert_eq!(read_size, read_data.len());
+        }
+    }
+    assert_eq!(remove_protected_file(fname).is_ok(), true);
+}

--- a/tests/module_test.sh
+++ b/tests/module_test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+trap "pkill -2 -P $$; wait" SIGINT SIGTERM EXIT
+
+echo "[+] Running module test: protected_fs_rs ..." 
+cd ../mesatee_utils/protected_fs_rs
+cargo test

--- a/toolchain_deps/Cargo.unix_app.toml
+++ b/toolchain_deps/Cargo.unix_app.toml
@@ -13,6 +13,7 @@ members = [
   "examples/kmeans",
   "mesatee_sdk",
   "mesatee_sdk/c_sdk",
+  "mesatee_utils/protected_fs_rs",
 ]
 
 exclude = [


### PR DESCRIPTION
## Description

Ported sgxfs (Rust SGX SDK)  and sgx_protected_fs (Intel SGX SDK) to Unix target. We can use the protected_fs_rs crate to encrypt and transform large input files in non-SGX environment .

Fixes # (issue)

## Type of change (select applied and DELETE the others)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How Has This Been Tested?

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
