### PR TITLE
Upgrade dependencies

### DIFF
--- a/examples/online_decrypt/Cargo.toml
+++ b/examples/online_decrypt/Cargo.toml
@@ -12,5 +12,5 @@ base64 = { version = "0.10.1" }
 serde_derive = { version = "1.0.92" }
 serde_json = { version = "1.0.39" }
 serde = { version = "1.0.92" }
-ring = { version = "0.14.6" }
+ring = { version = "0.16.5" }
 lazy_static = { version = "1.3.0" }

--- a/examples/online_decrypt/src/main.rs
+++ b/examples/online_decrypt/src/main.rs
@@ -96,7 +96,7 @@ fn encrypt_data(mut data: Vec<u8>, aes_key: &[u8], aes_nonce: &[u8], aes_ad: &[u
     let mut s_key = aead::SealingKey::new(ub, filesequence);
     let ad = Aad::from(aes_ad);
     let s_result = s_key.seal_in_place_append_tag(ad, &mut data);
-    let _ = s_result.unwrap();
+    s_result.unwrap();
 
     data
 }

--- a/examples/online_decrypt/src/main.rs
+++ b/examples/online_decrypt/src/main.rs
@@ -67,9 +67,9 @@ impl AEADKeyConfig {
     }
 }
 
-struct FileNonceSequence(Option<aead::Nonce>);
+struct OneNonceSequence(Option<aead::Nonce>);
 
-impl FileNonceSequence {
+impl OneNonceSequence {
     /// Constructs the sequence allowing `advance()` to be called
     /// `allowed_invocations` times.
     fn new(nonce: aead::Nonce) -> Self {
@@ -77,7 +77,7 @@ impl FileNonceSequence {
     }
 }
 
-impl aead::NonceSequence for FileNonceSequence {
+impl aead::NonceSequence for OneNonceSequence {
     fn advance(&mut self) -> core::result::Result<aead::Nonce, ring::error::Unspecified> {
         self.0.take().ok_or(ring::error::Unspecified)
     }
@@ -91,7 +91,7 @@ fn encrypt_data(mut data: Vec<u8>, aes_key: &[u8], aes_nonce: &[u8], aes_ad: &[u
 
     let ub = UnboundKey::new(aead_alg, aes_key).unwrap();
     let nonce = Nonce::try_assume_unique_for_key(aes_nonce).unwrap();
-    let filesequence = FileNonceSequence::new(nonce);
+    let filesequence = OneNonceSequence::new(nonce);
 
     let mut s_key = aead::SealingKey::new(ub, filesequence);
     let ad = Aad::from(aes_ad);

--- a/mesatee_core/Cargo.toml
+++ b/mesatee_core/Cargo.toml
@@ -21,18 +21,17 @@ log          = { version = "0.4.6" }
 serde        = { version = "1.0.92" }
 serde_derive = { version = "1.0.92" }
 serde_json   = { version = "1.0.39" }
-rustls       = { version = "0.15.2", features = ["dangerous_configuration"] }
+rustls       = { version = "0.16.0", features = ["dangerous_configuration"] }
 lazy_static  = { version = "1.0.2", features = ["spin_no_std"] }
 chrono       = { version = "0.4.6" }
-ring         = { version = "0.14.6" }
-webpki       = { version = "0.19.1" }
-webpki-roots = { version = "0.16.0" }
+ring         = { version = "0.16.5" }
+webpki       = { version = "0.21.0" }
+webpki-roots = { version = "0.17.0" }
 base64       = { version = "0.10.1" }
 yasna        = { version = "0.3.0", features = ["bit-vec", "num-bigint", "chrono"] }
 num-bigint   = { version = "0.2.2" }
 bit-vec      = { version = "0.6.1", default-features = false }
 httparse     = { version = "1.3.2", default-features = false }
-untrusted    = { version = "0.6.2" }
 uuid         = { version = "0.7.4", features = ["v4"] }
 net2         = { version = "0.2.33" }
 

--- a/mesatee_core/src/rpc/sgx/auth.rs
+++ b/mesatee_core/src/rpc/sgx/auth.rs
@@ -25,7 +25,6 @@ use serde_json::Value;
 use std::convert::TryFrom;
 use std::io::BufReader;
 use std::time::*;
-use untrusted;
 
 #[cfg(feature = "mesalock_sgx")]
 use std::untrusted::time::SystemTimeEx;
@@ -258,7 +257,7 @@ pub(crate) fn extract_sgx_quote_from_mra_cert(
     }
     .map_err(|_| CertVerificationError::InvalidCertFormat)?;
 
-    let sig_cert = webpki::EndEntityCert::from(untrusted::Input::from(&sig_cert_dec))
+    let sig_cert = webpki::EndEntityCert::from(&sig_cert_dec)
         .map_err(|_| CertVerificationError::InvalidCertFormat)?;
 
     // Verify if the signing cert is issued by Intel CA
@@ -271,7 +270,6 @@ pub(crate) fn extract_sgx_quote_from_mra_cert(
     let ias_ca_core: &[u8] = &ias_ca_stripped[head_len..full_len - tail_len];
     let ias_cert_dec = base64::decode_config(ias_ca_core, base64::STANDARD)
         .map_err(|_| CertVerificationError::InvalidCertFormat)?;
-    let ias_cert_input = untrusted::Input::from(&ias_cert_dec);
 
     let mut ca_reader = BufReader::new(&ias_report_ca[..]);
 
@@ -286,7 +284,7 @@ pub(crate) fn extract_sgx_quote_from_mra_cert(
         .map(|cert| cert.to_trust_anchor())
         .collect();
 
-    let chain: Vec<untrusted::Input> = vec![ias_cert_input];
+    let chain: Vec<&[u8]> = vec![&ias_cert_dec];
 
     let now_func = webpki::Time::try_from(SystemTime::now())
         .map_err(|_| CertVerificationError::WebpkiFailure)?;
@@ -302,11 +300,7 @@ pub(crate) fn extract_sgx_quote_from_mra_cert(
 
     // Verify the signature against the signing cert
     sig_cert
-        .verify_signature(
-            &webpki::RSA_PKCS1_2048_8192_SHA256,
-            untrusted::Input::from(&attn_report_raw),
-            untrusted::Input::from(&sig),
-        )
+        .verify_signature(&webpki::RSA_PKCS1_2048_8192_SHA256, &attn_report_raw, &sig)
         .map_err(|_| CertVerificationError::WebpkiFailure)?;
 
     // Verify attestation report

--- a/mesatee_core/src/rpc/sgx/utils.rs
+++ b/mesatee_core/src/rpc/sgx/utils.rs
@@ -140,14 +140,6 @@ pub fn load_and_verify_enclave_info(
             .read_to_end(&mut sig)
             .unwrap_or_else(|_| panic!("cannot read signature from {:?}", signer.1));
 
-        //#[allow(deprecated)]
-        //ring::signature::verify(
-        //    &ring::signature::RSA_PKCS1_2048_8192_SHA256,
-        //    untrusted::Input::from(signer.0),
-        //    untrusted::Input::from(content.as_bytes()),
-        //    untrusted::Input::from(sig.as_slice()),
-        //)
-        //.expect("invalid signature for enclave info file");
         use ring::signature;
         let public_key =
             signature::UnparsedPublicKey::new(&signature::RSA_PKCS1_2048_8192_SHA256, signer.0);

--- a/mesatee_core/src/rpc/sgx/utils.rs
+++ b/mesatee_core/src/rpc/sgx/utils.rs
@@ -140,14 +140,20 @@ pub fn load_and_verify_enclave_info(
             .read_to_end(&mut sig)
             .unwrap_or_else(|_| panic!("cannot read signature from {:?}", signer.1));
 
-        #[allow(deprecated)]
-        ring::signature::verify(
-            &ring::signature::RSA_PKCS1_2048_8192_SHA256,
-            untrusted::Input::from(signer.0),
-            untrusted::Input::from(content.as_bytes()),
-            untrusted::Input::from(sig.as_slice()),
-        )
-        .expect("invalid signature for enclave info file");
+        //#[allow(deprecated)]
+        //ring::signature::verify(
+        //    &ring::signature::RSA_PKCS1_2048_8192_SHA256,
+        //    untrusted::Input::from(signer.0),
+        //    untrusted::Input::from(content.as_bytes()),
+        //    untrusted::Input::from(sig.as_slice()),
+        //)
+        //.expect("invalid signature for enclave info file");
+        use ring::signature;
+        let public_key =
+            signature::UnparsedPublicKey::new(&signature::RSA_PKCS1_2048_8192_SHA256, signer.0);
+        public_key
+            .verify(content.as_bytes(), sig.as_slice())
+            .expect("aa");
     }
 
     let lines: Vec<&str> = content.split('\n').collect();

--- a/mesatee_core/src/rpc/sgx/utils.rs
+++ b/mesatee_core/src/rpc/sgx/utils.rs
@@ -145,7 +145,7 @@ pub fn load_and_verify_enclave_info(
             signature::UnparsedPublicKey::new(&signature::RSA_PKCS1_2048_8192_SHA256, signer.0);
         public_key
             .verify(content.as_bytes(), sig.as_slice())
-            .expect("aa");
+            .expect("invalid signature for enclave info file");
     }
 
     let lines: Vec<&str> = content.split('\n').collect();

--- a/mesatee_services/fns/sgx_trusted_lib/Cargo.toml
+++ b/mesatee_services/fns/sgx_trusted_lib/Cargo.toml
@@ -27,8 +27,8 @@ base64               = { version = "0.10.1" }
 itertools            = { version = "0.8.0", default-features = false }
 log                  = { version = "0.4.7", features = ["max_level_trace"] }
 env_logger           = { version = "0.6.1" }
-image                = { version = "0.21.0" }
-ring                 = { version = "0.14.6" }
+image                = { version = "0.22.1" }
+ring                 = { version = "0.16.5" }
 uuid                 = { version = "0.7.4", features = ["v4"] }
 
 mesatee_core         = { version = "0.1.0" }

--- a/mesatee_services/fns/sgx_trusted_lib/src/trusted_worker/online_decrypt.rs
+++ b/mesatee_services/fns/sgx_trusted_lib/src/trusted_worker/online_decrypt.rs
@@ -14,9 +14,7 @@
 
 use crate::worker::{FunctionType, Worker, WorkerContext};
 use mesatee_core::{Error, ErrorKind, Result};
-use ring::aead;
-use ring::aead::Aad;
-use ring::aead::Nonce;
+use ring::aead::{self, Aad, BoundKey, Nonce, UnboundKey};
 use serde_derive::Deserialize;
 use serde_json;
 use std::prelude::v1::*;
@@ -109,6 +107,22 @@ impl Worker for OnlineDecryptWorker {
     }
 }
 
+struct FileNonceSequence(Option<aead::Nonce>);
+
+impl FileNonceSequence {
+    /// Constructs the sequence allowing `advance()` to be called
+    /// `allowed_invocations` times.
+    fn new(nonce: aead::Nonce) -> Self {
+        Self(Some(nonce))
+    }
+}
+
+impl aead::NonceSequence for FileNonceSequence {
+    fn advance(&mut self) -> core::result::Result<aead::Nonce, ring::error::Unspecified> {
+        self.0.take().ok_or(ring::error::Unspecified)
+    }
+}
+
 fn decrypt_data(
     mut data: Vec<u8>,
     aes_key: &[u8],
@@ -116,12 +130,13 @@ fn decrypt_data(
     aes_ad: &[u8],
 ) -> Result<Vec<u8>> {
     let aead_alg = &aead::AES_256_GCM;
-    let o_key = aead::OpeningKey::new(aead_alg, aes_key)
-        .map_err(|_| mesatee_core::Error::from(mesatee_core::ErrorKind::CryptoError))?;
+    let ub = UnboundKey::new(aead_alg, aes_key).map_err(|_| Error::from(ErrorKind::CryptoError))?;
     let nonce = Nonce::try_assume_unique_for_key(aes_nonce)
         .map_err(|_| mesatee_core::Error::from(mesatee_core::ErrorKind::CryptoError))?;
+    let filesequence = FileNonceSequence::new(nonce);
+    let mut o_key = aead::OpeningKey::new(ub, filesequence);
     let ad = Aad::from(aes_ad);
-    let result = aead::open_in_place(&o_key, nonce, ad, 0, &mut data[..]);
+    let result = o_key.open_in_place(ad, &mut data[..]);
     let decrypted_buffer =
         result.map_err(|_| mesatee_core::Error::from(mesatee_core::ErrorKind::CryptoError))?;
     Ok(decrypted_buffer.to_vec())

--- a/mesatee_services/tdfs/external/client/Cargo.toml
+++ b/mesatee_services/tdfs/external/client/Cargo.toml
@@ -12,6 +12,6 @@ default = []
 
 [dependencies]
 cfg-if       = { version = "0.1.9" }
-ring         = { version = "0.14.6" }
+ring         = { version = "0.16.5" }
 mesatee_core = { version = "0.1.0" }
 tdfs_external_proto = { path = "../proto" }

--- a/mesatee_services/tdfs/internal/client/Cargo.toml
+++ b/mesatee_services/tdfs/internal/client/Cargo.toml
@@ -13,7 +13,7 @@ cov = ["sgx_cov"]
 
 [dependencies]
 cfg-if       = { version = "0.1.9" }
-ring         = { version = "0.14.6" }
+ring         = { version = "0.16.5" }
 net2         = { version = "0.2.33" }
 
 kms_client          = { path = "../../../kms/client", optional = true}

--- a/mesatee_services/tdfs/internal/client/src/file_util.rs
+++ b/mesatee_services/tdfs/internal/client/src/file_util.rs
@@ -21,9 +21,9 @@ use ring::aead::{self, Aad, BoundKey, Nonce, UnboundKey};
 use ring::digest;
 use std::fmt::Write;
 
-struct FileNonceSequence(Option<aead::Nonce>);
+struct OneNonceSequence(Option<aead::Nonce>);
 
-impl FileNonceSequence {
+impl OneNonceSequence {
     /// Constructs the sequence allowing `advance()` to be called
     /// `allowed_invocations` times.
     fn new(nonce: aead::Nonce) -> Self {
@@ -31,7 +31,7 @@ impl FileNonceSequence {
     }
 }
 
-impl aead::NonceSequence for FileNonceSequence {
+impl aead::NonceSequence for OneNonceSequence {
     fn advance(&mut self) -> core::result::Result<aead::Nonce, ring::error::Unspecified> {
         self.0.take().ok_or(ring::error::Unspecified)
     }
@@ -47,7 +47,7 @@ pub fn decrypt_data(
     let ub = UnboundKey::new(aead_alg, aes_key).map_err(|_| Error::from(ErrorKind::CryptoError))?;
     let nonce = Nonce::try_assume_unique_for_key(aes_nonce)
         .map_err(|_| Error::from(ErrorKind::CryptoError))?;
-    let filesequence = FileNonceSequence::new(nonce);
+    let filesequence = OneNonceSequence::new(nonce);
     let mut o_key = aead::OpeningKey::new(ub, filesequence);
     let ad = Aad::from(aes_ad);
     let result = o_key.open_in_place(ad, &mut data[..]);
@@ -70,7 +70,7 @@ pub fn encrypt_data(
     let ub = UnboundKey::new(aead_alg, aes_key).map_err(|_| Error::from(ErrorKind::CryptoError))?;
     let nonce = Nonce::try_assume_unique_for_key(aes_nonce)
         .map_err(|_| Error::from(ErrorKind::CryptoError))?;
-    let filesequence = FileNonceSequence::new(nonce);
+    let filesequence = OneNonceSequence::new(nonce);
     let mut s_key = aead::SealingKey::new(ub, filesequence);
     let ad = Aad::from(aes_ad);
 

--- a/mesatee_services/tdfs/internal/client/src/file_util.rs
+++ b/mesatee_services/tdfs/internal/client/src/file_util.rs
@@ -17,11 +17,25 @@
 use std::prelude::v1::*;
 
 use mesatee_core::{Error, ErrorKind, Result};
-use ring::aead;
-use ring::aead::Aad;
-use ring::aead::Nonce;
+use ring::aead::{self, Aad, BoundKey, Nonce, UnboundKey};
 use ring::digest;
 use std::fmt::Write;
+
+struct FileNonceSequence(Option<aead::Nonce>);
+
+impl FileNonceSequence {
+    /// Constructs the sequence allowing `advance()` to be called
+    /// `allowed_invocations` times.
+    fn new(nonce: aead::Nonce) -> Self {
+        Self(Some(nonce))
+    }
+}
+
+impl aead::NonceSequence for FileNonceSequence {
+    fn advance(&mut self) -> core::result::Result<aead::Nonce, ring::error::Unspecified> {
+        self.0.take().ok_or(ring::error::Unspecified)
+    }
+}
 
 pub fn decrypt_data(
     mut data: Vec<u8>,
@@ -30,12 +44,13 @@ pub fn decrypt_data(
     aes_ad: &[u8],
 ) -> Result<Vec<u8>> {
     let aead_alg = &aead::AES_256_GCM;
-    let o_key = aead::OpeningKey::new(aead_alg, aes_key)
-        .map_err(|_| Error::from(ErrorKind::CryptoError))?;
+    let ub = UnboundKey::new(aead_alg, aes_key).map_err(|_| Error::from(ErrorKind::CryptoError))?;
     let nonce = Nonce::try_assume_unique_for_key(aes_nonce)
         .map_err(|_| Error::from(ErrorKind::CryptoError))?;
+    let filesequence = FileNonceSequence::new(nonce);
+    let mut o_key = aead::OpeningKey::new(ub, filesequence);
     let ad = Aad::from(aes_ad);
-    let result = aead::open_in_place(&o_key, nonce, ad, 0, &mut data[..]);
+    let result = o_key.open_in_place(ad, &mut data[..]);
     let decrypted_buffer = result.map_err(|_| Error::from(ErrorKind::CryptoError))?;
     Ok(decrypted_buffer.to_vec())
 }
@@ -47,26 +62,23 @@ pub fn encrypt_data(
     aes_ad: &[u8],
 ) -> Result<Vec<u8>> {
     let aead_alg = &aead::AES_256_GCM;
-    let tag_len = aead_alg.tag_len();
-    for _ in 0..aead_alg.tag_len() {
-        data.push(0);
-    }
 
     if (aes_key.len() != 32) || (aes_nonce.len() != 12) || (aes_ad.len() != 5) {
         return Err(Error::from(ErrorKind::CryptoError));
     }
 
-    let s_key = aead::SealingKey::new(aead_alg, &aes_key[..])
-        .or_else(|_| Err(Error::from(ErrorKind::CryptoError)))?;
+    let ub = UnboundKey::new(aead_alg, aes_key).map_err(|_| Error::from(ErrorKind::CryptoError))?;
     let nonce = Nonce::try_assume_unique_for_key(aes_nonce)
         .map_err(|_| Error::from(ErrorKind::CryptoError))?;
+    let filesequence = FileNonceSequence::new(nonce);
+    let mut s_key = aead::SealingKey::new(ub, filesequence);
     let ad = Aad::from(aes_ad);
 
-    let s_result = { aead::seal_in_place(&s_key, nonce, ad, &mut data[..], tag_len) };
+    let s_result = s_key.seal_in_place_append_tag(ad, &mut data);
 
-    let result_len = s_result.map_err(|_| Error::from(ErrorKind::CryptoError))?;
+    let _ = s_result.map_err(|_| Error::from(ErrorKind::CryptoError))?;
 
-    Ok(data[..result_len].to_vec())
+    Ok(data)
 }
 
 pub fn cal_hash(data: &[u8]) -> Result<String> {

--- a/mesatee_services/tdfs/internal/client/src/file_util.rs
+++ b/mesatee_services/tdfs/internal/client/src/file_util.rs
@@ -76,7 +76,7 @@ pub fn encrypt_data(
 
     let s_result = s_key.seal_in_place_append_tag(ad, &mut data);
 
-    let _ = s_result.map_err(|_| Error::from(ErrorKind::CryptoError))?;
+    s_result.map_err(|_| Error::from(ErrorKind::CryptoError))?;
 
     Ok(data)
 }

--- a/tests/integration_test/Cargo.toml
+++ b/tests/integration_test/Cargo.toml
@@ -17,8 +17,8 @@ serde = "1.0.92"
 serde_json = "1.0.39"
 failure = "0.1.5"
 exitfailure = "0.5.1"
-rustls = { version = "0.15.2", features = ["dangerous_configuration"] }
-webpki = "0.19.1"
+rustls = { version = "0.16.0", features = ["dangerous_configuration"] }
+webpki = "0.21.0"
 regex = "1.1.7"
 wabt = "0.4.0"
 nan-preserving-float = "0.1.0"

--- a/toolchain_deps/Cargo.sgx_trusted_lib.toml
+++ b/toolchain_deps/Cargo.sgx_trusted_lib.toml
@@ -71,7 +71,7 @@ png               = { git = "https://github.com/mesalock-linux/image-png-sgx" }
 profiler_builtins = { git = "https://github.com/mesalock-linux/sgx-fake-profiler-builtins" }
 quick-error       = { git = "https://github.com/mesalock-linux/quick-error-sgx" }
 regex             = { git = "https://github.com/mesalock-linux/regex-sgx" }
-ring              = { git = "https://github.com/mesalock-linux/ring-sgx", tag = "v0.14.6" }
+ring              = { git = "https://github.com/mesalock-linux/ring-sgx", tag = "v0.16.5" }
 rustls            = { git = "https://github.com/mesalock-linux/rustls", branch = "mesalock_sgx" }
 sct               = { git = "https://github.com/mesalock-linux/sct.rs", branch = "mesalock_sgx" }
 serde             = { git = "https://github.com/mesalock-linux/serde-sgx" }
@@ -79,7 +79,6 @@ serde_derive      = { git = "https://github.com/mesalock-linux/serde-sgx" }
 serde_json        = { git = "https://github.com/mesalock-linux/serde-json-sgx" }
 tiff              = { git = "https://github.com/mesalock-linux/image-tiff-sgx" }
 toml              = { git = "https://github.com/mesalock-linux/toml-rs-sgx" }
-untrusted         = { git = "https://github.com/briansmith/untrusted", tag = "ring-master" }
 uuid              = { git = "https://github.com/mesalock-linux/uuid-sgx" }
 wabt              = { git = "https://github.com/mesalock-linux/wabt-rs-sgx", branch = "v0.6.0-core" }
 wasmi             = { git = "https://github.com/mesalock-linux/wasmi-sgx" }


### PR DESCRIPTION
## Description

Upgrade dependencies. Major changes include: 

- ring => 0.16.5
- rustls => 0.16
- webpki => 0.21.0
- webpki-roots => 0.17.0

For the whole list, please access the [diff](https://github.com/mesalock-linux/crates-sgx/commit/a9462e3f2e95878e8dff931ff8ac9a75579dc6c1#diff-26fd799ea07494916e9da9b91b2aac64).

## Type of change (select applied and DELETE the others)

- [x] Code cleanup or just sync with upstream third-party crates

## How Has This Been Tested?

Completed all CI tests.

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
