### PR TITLE
Fix 16.04 building problem and upgrade third party crates

### DIFF
--- a/toolchain_deps/Cargo.sgx_trusted_lib.toml
+++ b/toolchain_deps/Cargo.sgx_trusted_lib.toml
@@ -66,7 +66,7 @@ log               = { git = "https://github.com/mesalock-linux/log-sgx" }
 lzw               = { git = "https://github.com/mesalock-linux/lzw-sgx" }
 num-bigint        = { git = "https://github.com/mesalock-linux/num-bigint-sgx" }
 num-traits        = { git = "https://github.com/mesalock-linux/num-traits-sgx" }
-parity-wasm       = { git = "https://github.com/mesalock-linux/parity-wasm-sgx", branch = "v0.31.3" }
+parity-wasm       = { git = "https://github.com/mesalock-linux/parity-wasm-sgx" }
 png               = { git = "https://github.com/mesalock-linux/image-png-sgx" }
 profiler_builtins = { git = "https://github.com/mesalock-linux/sgx-fake-profiler-builtins" }
 quick-error       = { git = "https://github.com/mesalock-linux/quick-error-sgx" }


### PR DESCRIPTION
## Description

Old sgx_unwind contains unnecessary source files which should be excluded. This commit fix the sgx_unwind build problem, as well as update third party libraries.

Fixes #29 

## Type of change (select applied and DELETE the others)

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup or just sync with upstream third-party crates

## How Has This Been Tested?

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
