### PR TITLE
mesapy_exec: pass args (context_id, context_token) for the mesapy worker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ SET_STRVAR_FROM_ENV_OR(SGX_SDK "/opt/sgxsdk" "Path of SGX SDK")
 SET_STRVAR_FROM_ENV_OR(SGX_MODE "HW" "Mode of SGX, HW or SW")
 SET_STRVAR_FROM_ENV_OR(RUSTFLAGS "" "Rust flags")
 SET_STRVAR_FROM_ENV_OR(MESATEE_CMAKE_DBG "" "set to turn on debug message for cmake")
-set(MESAPY_VERSION 544d70a041643eed8a0f362e9746facb254381af CACHE STRING "mesapy version")
+set(MESAPY_VERSION 118324d6fcf7303bd9d76c3ed7f6009302177575 CACHE STRING "mesapy version")
 option(COV OFF "Turn on coverage or not")
 # ======= VARIABLES FOR CMAKE -D{VAR}=VAL CONFIGURATION END =======
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 SHELL = /bin/bash
 
-MESAPY_VERSION = 544d70a041643eed8a0f362e9746facb254381af
+MESAPY_VERSION = 118324d6fcf7303bd9d76c3ed7f6009302177575
 
 SGX_ENCLAVE_FEATURES = -Z package-features --features mesalock_sgx
 ifeq ($(DBG),) 	# Release build

--- a/examples/py_matrix_multiply/payload.py
+++ b/examples/py_matrix_multiply/payload.py
@@ -1,7 +1,8 @@
 from ffi import ffi
 import _numpypy as np
 
-def entrypoint():
+def entrypoint(argv):
+    context_id, context_token = argv
     x = get_matrix(10)
     y = get_matrix(10)
     z = x.dot(y)

--- a/examples/py_matrix_multiply/py_matrix_multiply.sh
+++ b/examples/py_matrix_multiply/py_matrix_multiply.sh
@@ -18,4 +18,4 @@ for port in 5554 5555 3444 6016 5065 5066; do
 done
 
 $BIN $PY_SCRIPT > $RESULT_PATH # result is in Python marshal format
-cmp --silent $RESULT_PATH $GROUND_TRUTH && echo "Python Execution Successful" || exit 1
+cmp $RESULT_PATH $GROUND_TRUTH && echo "Python Execution Successful" || exit 1

--- a/tests/integration_test/src/mesapy.rs
+++ b/tests/integration_test/src/mesapy.rs
@@ -19,7 +19,7 @@ pub fn test_mesapy() {
     trace!(">>>>> mesapy");
     let request = base64::encode(
         "
-def entrypoint():
+def entrypoint(argv):
     print('Hello Python World!')
     ",
     );


### PR DESCRIPTION
## Description

Support passing arguments (context_id, context_token) for the mesapy worker. This is the first step to have more context related APIs in MesaPy.

## Type of change (select applied and DELETE the others)

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The argument passing function has been tested in MesaPy. The functional tests of mesapy's context-related APIs will be added after completing the implementation.

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
