### PR TITLE
mesatee_cli: delete the profile section to fix build warnings

### DIFF
--- a/mesatee_cli/Cargo.toml
+++ b/mesatee_cli/Cargo.toml
@@ -21,10 +21,3 @@ clap_flags = "0.2.0"
 tms_external_proto = { path = "../mesatee_services/tms/external/proto" }
 tdfs_external_proto = { path = "../mesatee_services/tdfs/external/proto" }
 fns_proto = { path = "../mesatee_services/fns/proto" }
-
-[profile.release]
-opt-level = 3
-debug = false
-lto = true
-debug-assertions = false
-codegen-units = 1


### PR DESCRIPTION
## Description

Delete the profile section to fix build warnings like this:

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
```

## Type of change (select applied and DELETE the others)

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No need to test.

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
