### PR TITLE
Disable assertion for K-means

### DIFF
--- a/examples/kmeans/kmeans_demo.sh
+++ b/examples/kmeans/kmeans_demo.sh
@@ -27,4 +27,7 @@ assert_eq() {
     echo "$1"
   fi
 }
-assert_eq "`$BIN $K_NUM $FEATURES_NUM $TEST_DATA_PATH | grep -Eo '[0-9]' | sort | uniq -c | sort -nr | awk '{print $1}' 2>&1`" "`cat $EXPECTED_RESULT`"
+
+# Since k-means randomly select initial points, the classification result is not
+# stable. Uncomment this line if you need to assert the result.
+# assert_eq "`$BIN $K_NUM $FEATURES_NUM $TEST_DATA_PATH | grep -Eo '[0-9]' | sort | uniq -c | sort -nr | awk '{print $1}' 2>&1`" "`cat $EXPECTED_RESULT`"


### PR DESCRIPTION
## Description

Disable assertion for the Kmeans example. Since Kmeans randomly select initial points, the classification result may be different sometimes.

## Type of change (select applied and DELETE the others)

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI.

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
