### PR TITLE
Fix repeated compilation

### DIFF
--- a/cmake/scripts/cc_wrapper.sh
+++ b/cmake/scripts/cc_wrapper.sh
@@ -6,4 +6,4 @@ for var in "${REQUIRED_ENVS[@]}"; do
 done
 
 # Tell gcc/clang to remap absolute src paths to make enclaves' signature more reproducible
-exec "${CMAKE_C_COMPILER}" "$@" -fdebug-prefix-map=${MESATEE_PROJECT_ROOT}=/mesatee_src -fdebug-prefix-map=${MESATEE_BUILD_ROOT}=/mesatee_build
+exec "${CMAKE_C_COMPILER}" "$@" -fdebug-prefix-map=${MESATEE_PROJECT_ROOT}=/tmp/mesatee_symlinks/mesatee_src -fdebug-prefix-map=${MESATEE_BUILD_ROOT}=/tmp/mesatee_symlinks/mesatee_build

--- a/cmake/scripts/prep.sh
+++ b/cmake/scripts/prep.sh
@@ -10,6 +10,11 @@ done
 
 ${MT_SCRIPT_DIR}/setup_cmake_tomls ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} 
 mkdir -p ${MESATEE_BIN_DIR} ${MESATEE_OUT_DIR} ${MESATEE_TARGET_DIR}
+# create the following symlinks to make remapped paths accessible and avoid repeated building
+mkdir -p /tmp/mesatee_symlinks
+ln -snf ${HOME}/.cargo /tmp/mesatee_symlinks/cargo_home
+ln -snf ${CMAKE_SOURCE_DIR} /tmp/mesatee_symlinks/mesatee_src
+ln -snf ${CMAKE_BINARY_DIR} /tmp/mesatee_symlinks/mesatee_build
 if git submodule status | egrep -q '^[-]|^[+]'; then echo 'INFO: Need to reinitialize git submodules' && git submodule update --init --recursive; fi
 rustup install --no-self-update ${RUSTUP_TOOLCHAIN} > /dev/null 2>&1
 # get mesapy

--- a/cmake/scripts/rustc_wrapper.sh
+++ b/cmake/scripts/rustc_wrapper.sh
@@ -6,4 +6,4 @@ for var in "${REQUIRED_ENVS[@]}"; do
 done
 
 # Tell rustc to remap absolute src paths to make enclaves' signature more reproducible
-exec rustc "$@" --remap-path-prefix=${HOME}/.cargo=/cargo_home --remap-path-prefix=${MESATEE_PROJECT_ROOT}=/mesatee_src --remap-path-prefix=${MESATEE_BUILD_ROOT}=/mesatee_build
+exec rustc "$@" --remap-path-prefix=${HOME}/.cargo=/tmp/mesatee_symlinks/cargo_home --remap-path-prefix=${MESATEE_PROJECT_ROOT}=/tmp/mesatee_symlinks/mesatee_src --remap-path-prefix=${MESATEE_BUILD_ROOT}=/tmp/mesatee_symlinks/mesatee_build


### PR DESCRIPTION
## Description

Create symlinks to make remapped paths accessible and avoid repeated building caused by num-traits.

/tmp/mesatee_symlinks/cargo_home
/tmp/mesatee_symlinks/mesatee_src
/tmp/mesatee_symlinks/mesatee_build

## Type of change (select applied and DELETE the others)

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Yes

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
