### PR TITLE
Remove requirement of high version Python3

### DIFF
--- a/cmake/MesaTEEUtils.cmake
+++ b/cmake/MesaTEEUtils.cmake
@@ -250,7 +250,7 @@ function(parse_cargo_packages packages_name)
     set(err)
 
     execute_process(
-        COMMAND python3 ${PROJECT_SOURCE_DIR}/cmake/scripts/parse_cargo_packages.py 
+        COMMAND python ${PROJECT_SOURCE_DIR}/cmake/scripts/parse_cargo_packages.py
             ${MC_CARGO_TOML_PATH} ${PROJECT_SOURCE_DIR}
         OUTPUT_VARIABLE _packages_name
         ERROR_VARIABLE err

--- a/cmake/scripts/parse_cargo_packages.py
+++ b/cmake/scripts/parse_cargo_packages.py
@@ -1,4 +1,12 @@
-
+'''
+This script parses Cargo.toml to generate a list of package to be built for CMake
+lines ending with "# ignore" will be omitted
+e.g.
+members = [
+  "examples/neural_net",
+  "mesatee_sdk", # ignore
+]
+'''
 import os
 import re
 import sys
@@ -37,7 +45,7 @@ def parse_package_name(package_toml_path):
 
 
 if len(sys.argv) < 3:
-    err = f"[usage] python3 {sys.argv[0]} cargo_toml_path workspace_path"
+    err = "[usage] python {} cargo_toml_path workspace_path".format(sys.argv[0])
     raise ValueError(err)
 
 toml_path = sys.argv[1]
@@ -52,4 +60,4 @@ for m in members:
 
     packages.append(pkg_name)
 
-print(";".join(packages), end="")
+sys.stdout.write(";".join(packages))


### PR DESCRIPTION
## Description
Improve parse_cargo_packages.py to fix the error when a high version Python3 is not available.
Add some description for the parse script.

## Type of change (select applied and DELETE the others)

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
